### PR TITLE
feat: disable Cloudflare Worker Logs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,3 @@ DNS_ROOT = ".calibration.filcdn.dev"
 binding = "DB"
 database_name = "filcdn-db"
 database_id = "filcdn-db"
-
-[observability.logs]
-enabled = true


### PR DESCRIPTION
We don't need to collect logs yet. For troubleshooting, we can use Live Logs.

This PR partially reverts #22/3dcc36c2d3f.
