### PR TITLE
fix: use withClientNotSanctioned to prevent sanctioned clients from being selected

### DIFF
--- a/retriever/lib/store.js
+++ b/retriever/lib/store.js
@@ -159,7 +159,9 @@ export async function getStorageProviderAndValidatePayer(
     `Wallet '${payerAddress}' is sanctioned and cannot retrieve piece_cid '${pieceCid}'.`,
   )
 
-  const withApprovedProvider = withCDN.filter((row) => row.service_url)
+  const withApprovedProvider = withPayerNotSanctioned.filter(
+    (row) => row.service_url,
+  )
   httpAssert(
     withApprovedProvider.length > 0,
     404,


### PR DESCRIPTION
### What’s Changed
- Replaced `withCDN.filter(...)` with `withClientNotSanctioned.filter(...)` when selecting an approved provider.
- This ensures that sanctioned clients are not included in provider selection logic.

Fixes #252 