### PR TITLE
feat(indexer, db): add provider RSR score storage with batch ops and conflict handling

### DIFF
--- a/db/migrations/0014_add_provider_rsr_scores.sql
+++ b/db/migrations/0014_add_provider_rsr_scores.sql
@@ -1,0 +1,25 @@
+-- Migration number: 0014 	 2025-01-27T00:00:00.000Z
+CREATE TABLE IF NOT EXISTS provider_rsr_scores (
+  provider_address TEXT NOT NULL,
+  score REAL NOT NULL,
+  calculated_at DATETIME NOT NULL,
+  calculation_period_start DATETIME NOT NULL,
+  calculation_period_end DATETIME NOT NULL,
+  total_requests INTEGER NOT NULL DEFAULT 0,
+  successful_requests INTEGER NOT NULL DEFAULT 0,
+  avg_response_time_ms REAL,
+  avg_ttfb_ms REAL,
+  avg_ttlb_ms REAL,
+  reliability_score REAL,
+  performance_score REAL,
+  PRIMARY KEY (provider_address, calculated_at)
+);
+
+-- Index for efficient querying by provider and time range
+CREATE INDEX IF NOT EXISTS idx_provider_rsr_scores_provider_time 
+ON provider_rsr_scores (provider_address, calculated_at DESC);
+
+-- Index for querying latest scores for all providers
+CREATE INDEX IF NOT EXISTS idx_provider_rsr_scores_latest 
+ON provider_rsr_scores (calculated_at DESC, provider_address);
+

--- a/indexer/lib/rsr-score-storage.js
+++ b/indexer/lib/rsr-score-storage.js
@@ -1,0 +1,341 @@
+/**
+ * RSR (Retrieval Success Rate) Score Storage and Persistence Module
+ * 
+ * This module provides functionality to store calculated RSR scores in the database
+ * and manage persistence over time with batch operations and conflict resolution.
+ */
+
+/**
+ * @typedef {Object} RSRScoreData
+ * @property {string} providerAddress - The storage provider's address
+ * @property {number} score - The calculated RSR score (0-1)
+ * @property {string} calculatedAt - ISO timestamp when the score was calculated
+ * @property {string} calculationPeriodStart - Start of the calculation period
+ * @property {string} calculationPeriodEnd - End of the calculation period
+ * @property {number} totalRequests - Total number of requests in the period
+ * @property {number} successfulRequests - Number of successful requests
+ * @property {number} [avgResponseTimeMs] - Average response time in milliseconds
+ * @property {number} [avgTtfbMs] - Average time to first byte in milliseconds
+ * @property {number} [avgTtlbMs] - Average time to last byte in milliseconds
+ * @property {number} [reliabilityScore] - Calculated reliability component
+ * @property {number} [performanceScore] - Calculated performance component
+ */
+
+/**
+ * Stores a single RSR score in the database with conflict resolution
+ * 
+ * @param {Pick<Env, 'DB'>} env - Worker environment with D1 DB binding
+ * @param {RSRScoreData} scoreData - The RSR score data to store
+ * @returns {Promise<void>}
+ */
+export async function storeRSRScore(env, scoreData) {
+  const {
+    providerAddress,
+    score,
+    calculatedAt,
+    calculationPeriodStart,
+    calculationPeriodEnd,
+    totalRequests,
+    successfulRequests,
+    avgResponseTimeMs,
+    avgTtfbMs,
+    avgTtlbMs,
+    reliabilityScore,
+    performanceScore,
+  } = scoreData
+
+  try {
+    await env.DB.prepare(
+      `
+      INSERT INTO provider_rsr_scores (
+        provider_address,
+        score,
+        calculated_at,
+        calculation_period_start,
+        calculation_period_end,
+        total_requests,
+        successful_requests,
+        avg_response_time_ms,
+        avg_ttfb_ms,
+        avg_ttlb_ms,
+        reliability_score,
+        performance_score
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(provider_address, calculated_at) DO UPDATE SET
+        score = excluded.score,
+        calculation_period_start = excluded.calculation_period_start,
+        calculation_period_end = excluded.calculation_period_end,
+        total_requests = excluded.total_requests,
+        successful_requests = excluded.successful_requests,
+        avg_response_time_ms = excluded.avg_response_time_ms,
+        avg_ttfb_ms = excluded.avg_ttfb_ms,
+        avg_ttlb_ms = excluded.avg_ttlb_ms,
+        reliability_score = excluded.reliability_score,
+        performance_score = excluded.performance_score
+      `
+    )
+      .bind(
+        providerAddress.toLowerCase(),
+        score,
+        calculatedAt,
+        calculationPeriodStart,
+        calculationPeriodEnd,
+        totalRequests,
+        successfulRequests,
+        avgResponseTimeMs ?? null,
+        avgTtfbMs ?? null,
+        avgTtlbMs ?? null,
+        reliabilityScore ?? null,
+        performanceScore ?? null,
+      )
+      .run()
+
+    console.log(`Stored RSR score for provider ${providerAddress}: ${score}`)
+  } catch (error) {
+    console.error(`Error storing RSR score for provider ${providerAddress}:`, error)
+    throw error
+  }
+}
+
+/**
+ * Stores multiple RSR scores in a batch operation for efficiency
+ * 
+ * @param {Pick<Env, 'DB'>} env - Worker environment with D1 DB binding
+ * @param {RSRScoreData[]} scoresData - Array of RSR score data to store
+ * @returns {Promise<void>}
+ */
+export async function storeRSRScoresBatch(env, scoresData) {
+  if (!scoresData || scoresData.length === 0) {
+    console.log('No RSR scores to store in batch')
+    return
+  }
+
+  try {
+    // Prepare batch insert statement
+    const stmt = env.DB.prepare(
+      `
+      INSERT INTO provider_rsr_scores (
+        provider_address,
+        score,
+        calculated_at,
+        calculation_period_start,
+        calculation_period_end,
+        total_requests,
+        successful_requests,
+        avg_response_time_ms,
+        avg_ttfb_ms,
+        avg_ttlb_ms,
+        reliability_score,
+        performance_score
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(provider_address, calculated_at) DO UPDATE SET
+        score = excluded.score,
+        calculation_period_start = excluded.calculation_period_start,
+        calculation_period_end = excluded.calculation_period_end,
+        total_requests = excluded.total_requests,
+        successful_requests = excluded.successful_requests,
+        avg_response_time_ms = excluded.avg_response_time_ms,
+        avg_ttfb_ms = excluded.avg_ttfb_ms,
+        avg_ttlb_ms = excluded.avg_ttlb_ms,
+        reliability_score = excluded.reliability_score,
+        performance_score = excluded.performance_score
+      `
+    )
+
+    // Prepare batch data
+    const batchData = scoresData.map(scoreData => [
+      scoreData.providerAddress.toLowerCase(),
+      scoreData.score,
+      scoreData.calculatedAt,
+      scoreData.calculationPeriodStart,
+      scoreData.calculationPeriodEnd,
+      scoreData.totalRequests,
+      scoreData.successfulRequests,
+      scoreData.avgResponseTimeMs ?? null,
+      scoreData.avgTtfbMs ?? null,
+      scoreData.avgTtlbMs ?? null,
+      scoreData.reliabilityScore ?? null,
+      scoreData.performanceScore ?? null,
+    ])
+
+    // Execute batch operation
+    await env.DB.batch(
+      batchData.map(data => stmt.bind(...data))
+    )
+
+    console.log(`Stored ${scoresData.length} RSR scores in batch operation`)
+  } catch (error) {
+    console.error('Error storing RSR scores in batch:', error)
+    throw error
+  }
+}
+
+/**
+ * Retrieves the latest RSR score for a specific provider
+ * 
+ * @param {Pick<Env, 'DB'>} env - Worker environment with D1 DB binding
+ * @param {string} providerAddress - The provider's address
+ * @returns {Promise<RSRScoreData | null>}
+ */
+export async function getLatestRSRScore(env, providerAddress) {
+  try {
+    const result = /** @type {RSRScoreData | null} */ (
+      await env.DB.prepare(
+        `
+        SELECT 
+          provider_address as providerAddress,
+          score,
+          calculated_at as calculatedAt,
+          calculation_period_start as calculationPeriodStart,
+          calculation_period_end as calculationPeriodEnd,
+          total_requests as totalRequests,
+          successful_requests as successfulRequests,
+          avg_response_time_ms as avgResponseTimeMs,
+          avg_ttfb_ms as avgTtfbMs,
+          avg_ttlb_ms as avgTtlbMs,
+          reliability_score as reliabilityScore,
+          performance_score as performanceScore
+        FROM provider_rsr_scores
+        WHERE provider_address = ?
+        ORDER BY calculated_at DESC
+        LIMIT 1
+        `
+      )
+        .bind(providerAddress.toLowerCase())
+        .first()
+    )
+
+    return result || null
+  } catch (error) {
+    console.error(`Error retrieving latest RSR score for provider ${providerAddress}:`, error)
+    throw error
+  }
+}
+
+/**
+ * Retrieves RSR scores for multiple providers within a time range
+ * 
+ * @param {Pick<Env, 'DB'>} env - Worker environment with D1 DB binding
+ * @param {string[]} providerAddresses - Array of provider addresses
+ * @param {string | null} [startTime] - Start time for the range (ISO string)
+ * @param {string | null} [endTime] - End time for the range (ISO string)
+ * @returns {Promise<RSRScoreData[]>}
+ */
+export async function getRSRScoresForProviders(
+  env,
+  providerAddresses,
+  startTime = null,
+  endTime = null
+) {
+  try {
+    let query = `
+      SELECT 
+        provider_address as providerAddress,
+        score,
+        calculated_at as calculatedAt,
+        calculation_period_start as calculationPeriodStart,
+        calculation_period_end as calculationPeriodEnd,
+        total_requests as totalRequests,
+        successful_requests as successfulRequests,
+        avg_response_time_ms as avgResponseTimeMs,
+        avg_ttfb_ms as avgTtfbMs,
+        avg_ttlb_ms as avgTtlbMs,
+        reliability_score as reliabilityScore,
+        performance_score as performanceScore
+      FROM provider_rsr_scores
+      WHERE provider_address IN (${providerAddresses.map(() => '?').join(', ')})
+    `
+    
+    const bindings = providerAddresses.map(addr => addr.toLowerCase())
+    
+    if (startTime) {
+      query += ' AND calculated_at >= ?'
+      bindings.push(startTime)
+    }
+    
+    if (endTime) {
+      query += ' AND calculated_at <= ?'
+      bindings.push(endTime)
+    }
+    
+    query += ' ORDER BY calculated_at DESC'
+
+    const results = await env.DB.prepare(query).bind(...bindings).all()
+    
+    return /** @type {RSRScoreData[]} */ (results.results || [])
+  } catch (error) {
+    console.error('Error retrieving RSR scores for providers:', error)
+    throw error
+  }
+}
+
+/**
+ * Retrieves all latest RSR scores for all providers
+ * 
+ * @param {Pick<Env, 'DB'>} env - Worker environment with D1 DB binding
+ * @returns {Promise<RSRScoreData[]>}
+ */
+export async function getAllLatestRSRScores(env) {
+  try {
+    const results = await env.DB.prepare(
+      `
+      SELECT 
+        provider_address as providerAddress,
+        score,
+        calculated_at as calculatedAt,
+        calculation_period_start as calculationPeriodStart,
+        calculation_period_end as calculationPeriodEnd,
+        total_requests as totalRequests,
+        successful_requests as successfulRequests,
+        avg_response_time_ms as avgResponseTimeMs,
+        avg_ttfb_ms as avgTtfbMs,
+        avg_ttlb_ms as avgTtlbMs,
+        reliability_score as reliabilityScore,
+        performance_score as performanceScore
+      FROM provider_rsr_scores
+      WHERE (provider_address, calculated_at) IN (
+        SELECT provider_address, MAX(calculated_at)
+        FROM provider_rsr_scores
+        GROUP BY provider_address
+      )
+      ORDER BY score DESC
+      `
+    ).all()
+
+    return /** @type {RSRScoreData[]} */ (results.results || [])
+  } catch (error) {
+    console.error('Error retrieving all latest RSR scores:', error)
+    throw error
+  }
+}
+
+/**
+ * Deletes old RSR scores beyond a specified retention period
+ * 
+ * @param {Pick<Env, 'DB'>} env - Worker environment with D1 DB binding
+ * @param {number} retentionDays - Number of days to retain scores
+ * @returns {Promise<number>} Number of deleted records
+ */
+export async function cleanupOldRSRScores(env, retentionDays = 90) {
+  try {
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays)
+    const cutoffISO = cutoffDate.toISOString()
+
+    const result = await env.DB.prepare(
+      'DELETE FROM provider_rsr_scores WHERE calculated_at < ?'
+    )
+      .bind(cutoffISO)
+      .run()
+
+    const deletedCount = result.meta.changes || 0
+    console.log(`Cleaned up ${deletedCount} old RSR scores older than ${retentionDays} days`)
+    
+    return deletedCount
+  } catch (error) {
+    console.error('Error cleaning up old RSR scores:', error)
+    throw error
+  }
+}

--- a/indexer/test/rsr-score-storage.test.js
+++ b/indexer/test/rsr-score-storage.test.js
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  storeRSRScore,
+  storeRSRScoresBatch,
+  getLatestRSRScore,
+  getRSRScoresForProviders,
+  getAllLatestRSRScores,
+  cleanupOldRSRScores,
+} from '../lib/rsr-score-storage.js'
+import {
+  createRSRScoreData,
+  createMultipleRSRScoreData,
+  createHighPerformingProviderScore,
+  createLowPerformingProviderScore,
+  createMinimalProviderScore,
+  createHistoricalRSRScore,
+} from './rsr-score-test-data.js'
+
+describe('RSR Score Storage', () => {
+  let mockEnv
+  let mockDB
+  let mockStmt
+  let mockBatch
+
+  beforeEach(() => {
+    mockStmt = {
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+      first: vi.fn().mockResolvedValue(null),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+    }
+
+    mockBatch = vi.fn().mockResolvedValue({})
+
+    mockDB = {
+      prepare: vi.fn().mockReturnValue(mockStmt),
+      batch: mockBatch,
+    }
+
+    mockEnv = {
+      DB: mockDB,
+    }
+  })
+
+  describe('storeRSRScore', () => {
+    it('should store a single RSR score successfully', async () => {
+      const scoreData = createRSRScoreData()
+
+      await storeRSRScore(mockEnv, scoreData)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO provider_rsr_scores')
+      )
+      expect(mockStmt.bind).toHaveBeenCalledWith(
+        '0x1234567890123456789012345678901234567890',
+        0.85,
+        '2025-01-27T10:00:00.000Z',
+        '2025-01-20T00:00:00.000Z',
+        '2025-01-27T00:00:00.000Z',
+        1000,
+        850,
+        250.5,
+        150.2,
+        300.8,
+        0.85,
+        0.75,
+      )
+      expect(mockStmt.run).toHaveBeenCalled()
+    })
+
+    it('should handle null optional values', async () => {
+      const scoreData = createMinimalProviderScore()
+
+      await storeRSRScore(mockEnv, scoreData)
+
+      expect(mockStmt.bind).toHaveBeenCalledWith(
+        '0x1234567890123456789012345678901234567890',
+        0.75,
+        '2025-01-27T10:00:00.000Z',
+        '2025-01-20T00:00:00.000Z',
+        '2025-01-27T00:00:00.000Z',
+        500,
+        375,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+    })
+
+    it('should handle database errors', async () => {
+      const scoreData = createRSRScoreData()
+
+      const dbError = new Error('Database connection failed')
+      mockStmt.run.mockRejectedValue(dbError)
+
+      await expect(storeRSRScore(mockEnv, scoreData)).rejects.toThrow('Database connection failed')
+    })
+  })
+
+  describe('storeRSRScoresBatch', () => {
+    it('should store multiple RSR scores in batch', async () => {
+      const scoresData = createMultipleRSRScoreData(2)
+
+      await storeRSRScoresBatch(mockEnv, scoresData)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO provider_rsr_scores')
+      )
+      expect(mockBatch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+        ])
+      )
+    })
+
+    it('should handle empty batch gracefully', async () => {
+      await storeRSRScoresBatch(mockEnv, [])
+
+      expect(mockDB.prepare).not.toHaveBeenCalled()
+      expect(mockBatch).not.toHaveBeenCalled()
+    })
+
+    it('should handle null batch gracefully', async () => {
+      await storeRSRScoresBatch(mockEnv, null)
+
+      expect(mockDB.prepare).not.toHaveBeenCalled()
+      expect(mockBatch).not.toHaveBeenCalled()
+    })
+
+    it('should handle batch with high and low performing providers', async () => {
+      const scoresData = [
+        createHighPerformingProviderScore(),
+        createLowPerformingProviderScore(),
+        createMinimalProviderScore(),
+      ]
+
+      await storeRSRScoresBatch(mockEnv, scoresData)
+
+      expect(mockBatch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+        ])
+      )
+    })
+  })
+
+  describe('getLatestRSRScore', () => {
+    it('should retrieve the latest RSR score for a provider', async () => {
+      const mockScore = {
+        providerAddress: '0x1234567890123456789012345678901234567890',
+        score: 0.85,
+        calculatedAt: '2025-01-27T10:00:00.000Z',
+        calculationPeriodStart: '2025-01-20T00:00:00.000Z',
+        calculationPeriodEnd: '2025-01-27T00:00:00.000Z',
+        totalRequests: 1000,
+        successfulRequests: 850,
+        avgResponseTimeMs: 250.5,
+        avgTtfbMs: 150.2,
+        avgTtlbMs: 300.8,
+        reliabilityScore: 0.85,
+        performanceScore: 0.75,
+      }
+
+      mockStmt.first.mockResolvedValue(mockScore)
+
+      const result = await getLatestRSRScore(mockEnv, '0x1234567890123456789012345678901234567890')
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT')
+      )
+      expect(mockStmt.bind).toHaveBeenCalledWith('0x1234567890123456789012345678901234567890')
+      expect(result).toEqual(mockScore)
+    })
+
+    it('should return null when no score is found', async () => {
+      mockStmt.first.mockResolvedValue(null)
+
+      const result = await getLatestRSRScore(mockEnv, '0x1234567890123456789012345678901234567890')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getRSRScoresForProviders', () => {
+    it('should retrieve scores for multiple providers', async () => {
+      const mockScores = [
+        {
+          providerAddress: '0x1111111111111111111111111111111111111111',
+          score: 0.90,
+          calculatedAt: '2025-01-27T10:00:00.000Z',
+        },
+        {
+          providerAddress: '0x2222222222222222222222222222222222222222',
+          score: 0.75,
+          calculatedAt: '2025-01-27T10:00:00.000Z',
+        },
+      ]
+
+      mockStmt.all.mockResolvedValue({ results: mockScores })
+
+      const providerAddresses = [
+        '0x1111111111111111111111111111111111111111',
+        '0x2222222222222222222222222222222222222222',
+      ]
+
+      const result = await getRSRScoresForProviders(mockEnv, providerAddresses)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE provider_address IN (?, ?)')
+      )
+      expect(mockStmt.bind).toHaveBeenCalledWith(
+        '0x1111111111111111111111111111111111111111',
+        '0x2222222222222222222222222222222222222222'
+      )
+      expect(result).toEqual(mockScores)
+    })
+
+    it('should handle time range filters', async () => {
+      mockStmt.all.mockResolvedValue({ results: [] })
+
+      const providerAddresses = ['0x1111111111111111111111111111111111111111']
+      const startTime = '2025-01-20T00:00:00.000Z'
+      const endTime = '2025-01-27T00:00:00.000Z'
+
+      await getRSRScoresForProviders(mockEnv, providerAddresses, startTime, endTime)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('AND calculated_at >= ?')
+      )
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('AND calculated_at <= ?')
+      )
+      expect(mockStmt.bind).toHaveBeenCalledWith(
+        '0x1111111111111111111111111111111111111111',
+        startTime,
+        endTime
+      )
+    })
+  })
+
+  describe('getAllLatestRSRScores', () => {
+    it('should retrieve all latest RSR scores', async () => {
+      const mockScores = [
+        {
+          providerAddress: '0x1111111111111111111111111111111111111111',
+          score: 0.90,
+          calculatedAt: '2025-01-27T10:00:00.000Z',
+        },
+        {
+          providerAddress: '0x2222222222222222222222222222222222222222',
+          score: 0.75,
+          calculatedAt: '2025-01-27T10:00:00.000Z',
+        },
+      ]
+
+      mockStmt.all.mockResolvedValue({ results: mockScores })
+
+      const result = await getAllLatestRSRScores(mockEnv)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE (provider_address, calculated_at) IN')
+      )
+      expect(result).toEqual(mockScores)
+    })
+  })
+
+  describe('cleanupOldRSRScores', () => {
+    it('should delete old RSR scores beyond retention period', async () => {
+      mockStmt.run.mockResolvedValue({ meta: { changes: 5 } })
+
+      const deletedCount = await cleanupOldRSRScores(mockEnv, 90)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        'DELETE FROM provider_rsr_scores WHERE calculated_at < ?'
+      )
+      expect(mockStmt.bind).toHaveBeenCalledWith(expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/))
+      expect(deletedCount).toBe(5)
+    })
+
+    it('should use default retention period when not specified', async () => {
+      mockStmt.run.mockResolvedValue({ meta: { changes: 3 } })
+
+      const deletedCount = await cleanupOldRSRScores(mockEnv)
+
+      expect(deletedCount).toBe(3)
+    })
+
+    it('should handle cleanup with custom retention period', async () => {
+      mockStmt.run.mockResolvedValue({ meta: { changes: 10 } })
+
+      const deletedCount = await cleanupOldRSRScores(mockEnv, 30)
+
+      expect(mockDB.prepare).toHaveBeenCalledWith(
+        'DELETE FROM provider_rsr_scores WHERE calculated_at < ?'
+      )
+      expect(deletedCount).toBe(10)
+    })
+  })
+
+  describe('Integration scenarios', () => {
+    it('should handle complete workflow: store, retrieve, and cleanup', async () => {
+      // Store a score
+      const scoreData = createRSRScoreData()
+      await storeRSRScore(mockEnv, scoreData)
+
+      // Retrieve the score
+      const mockRetrievedScore = { ...scoreData }
+      mockStmt.first.mockResolvedValue(mockRetrievedScore)
+      const retrieved = await getLatestRSRScore(mockEnv, scoreData.providerAddress)
+
+      expect(retrieved).toEqual(mockRetrievedScore)
+
+      // Cleanup old scores
+      mockStmt.run.mockResolvedValue({ meta: { changes: 1 } })
+      const deletedCount = await cleanupOldRSRScores(mockEnv, 1)
+
+      expect(deletedCount).toBe(1)
+    })
+
+    it('should handle batch operations with mixed data quality', async () => {
+      const scoresData = [
+        createHighPerformingProviderScore(),
+        createLowPerformingProviderScore(),
+        createMinimalProviderScore(),
+        createHistoricalRSRScore(30), // 30 days old
+        createHistoricalRSRScore(1),  // 1 day old
+      ]
+
+      await storeRSRScoresBatch(mockEnv, scoresData)
+
+      expect(mockBatch).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+          expect.objectContaining({ bind: expect.any(Function) }),
+        ])
+      )
+    })
+  })
+})

--- a/indexer/test/rsr-score-test-data.js
+++ b/indexer/test/rsr-score-test-data.js
@@ -1,0 +1,135 @@
+/**
+ * Test data builders for RSR score storage tests
+ */
+
+/**
+ * Creates a mock RSR score data object with default values
+ * @param {Partial<import('../lib/rsr-score-storage.js').RSRScoreData>} overrides - Override default values
+ * @returns {import('../lib/rsr-score-storage.js').RSRScoreData}
+ */
+export function createRSRScoreData(overrides = {}) {
+  const now = new Date()
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  return {
+    providerAddress: '0x1234567890123456789012345678901234567890',
+    score: 0.85,
+    calculatedAt: now.toISOString(),
+    calculationPeriodStart: weekAgo.toISOString(),
+    calculationPeriodEnd: now.toISOString(),
+    totalRequests: 1000,
+    successfulRequests: 850,
+    avgResponseTimeMs: 250.5,
+    avgTtfbMs: 150.2,
+    avgTtlbMs: 300.8,
+    reliabilityScore: 0.85,
+    performanceScore: 0.75,
+    ...overrides,
+  }
+}
+
+/**
+ * Creates multiple RSR score data objects for batch testing
+ * @param {number} count - Number of score objects to create
+ * @param {Partial<import('../lib/rsr-score-storage.js').RSRScoreData>} baseOverrides - Base overrides for all objects
+ * @returns {import('../lib/rsr-score-storage.js').RSRScoreData[]}
+ */
+export function createMultipleRSRScoreData(count, baseOverrides = {}) {
+  const scores = []
+  const baseScore = createRSRScoreData(baseOverrides)
+
+  for (let i = 0; i < count; i++) {
+    scores.push(createRSRScoreData({
+      ...baseScore,
+      providerAddress: `0x${(i + 1).toString().padStart(40, '0')}`,
+      score: 0.5 + (i * 0.1), // Varying scores from 0.5 to 0.9
+      totalRequests: 1000 + (i * 100),
+      successfulRequests: 850 + (i * 85),
+      ...baseOverrides,
+    }))
+  }
+
+  return scores
+}
+
+/**
+ * Creates RSR score data for a high-performing provider
+ * @param {Partial<import('../lib/rsr-score-storage.js').RSRScoreData>} overrides - Override default values
+ * @returns {import('../lib/rsr-score-storage.js').RSRScoreData}
+ */
+export function createHighPerformingProviderScore(overrides = {}) {
+  return createRSRScoreData({
+    providerAddress: '0x1111111111111111111111111111111111111111',
+    score: 0.95,
+    totalRequests: 2000,
+    successfulRequests: 1900,
+    avgResponseTimeMs: 150.0,
+    avgTtfbMs: 100.0,
+    avgTtlbMs: 200.0,
+    reliabilityScore: 0.95,
+    performanceScore: 0.90,
+    ...overrides,
+  })
+}
+
+/**
+ * Creates RSR score data for a low-performing provider
+ * @param {Partial<import('../lib/rsr-score-storage.js').RSRScoreData>} overrides - Override default values
+ * @returns {import('../lib/rsr-score-storage.js').RSRScoreData}
+ */
+export function createLowPerformingProviderScore(overrides = {}) {
+  return createRSRScoreData({
+    providerAddress: '0x2222222222222222222222222222222222222222',
+    score: 0.45,
+    totalRequests: 1000,
+    successfulRequests: 450,
+    avgResponseTimeMs: 500.0,
+    avgTtfbMs: 300.0,
+    avgTtlbMs: 600.0,
+    reliabilityScore: 0.45,
+    performanceScore: 0.40,
+    ...overrides,
+  })
+}
+
+/**
+ * Creates RSR score data for a provider with missing optional metrics
+ * @param {Partial<import('../lib/rsr-score-storage.js').RSRScoreData>} overrides - Override default values
+ * @returns {import('../lib/rsr-score-storage.js').RSRScoreData}
+ */
+export function createMinimalProviderScore(overrides = {}) {
+  return createRSRScoreData({
+    providerAddress: '0x3333333333333333333333333333333333333333',
+    score: 0.70,
+    totalRequests: 500,
+    successfulRequests: 350,
+    avgResponseTimeMs: undefined,
+    avgTtfbMs: undefined,
+    avgTtlbMs: undefined,
+    reliabilityScore: undefined,
+    performanceScore: undefined,
+    ...overrides,
+  })
+}
+
+/**
+ * Creates RSR score data with historical timestamps
+ * @param {number} daysAgo - Number of days ago the score was calculated
+ * @param {Partial<import('../lib/rsr-score-storage.js').RSRScoreData>} overrides - Override default values
+ * @returns {import('../lib/rsr-score-storage.js').RSRScoreData}
+ */
+export function createHistoricalRSRScore(daysAgo, overrides = {}) {
+  const calculatedAt = new Date()
+  calculatedAt.setDate(calculatedAt.getDate() - daysAgo)
+
+  const periodStart = new Date(calculatedAt.getTime() - 7 * 24 * 60 * 60 * 1000)
+  const periodEnd = new Date(calculatedAt.getTime())
+
+  return createRSRScoreData({
+    calculatedAt: calculatedAt.toISOString(),
+    calculationPeriodStart: periodStart.toISOString(),
+    calculationPeriodEnd: periodEnd.toISOString(),
+    ...overrides,
+  })
+}
+


### PR DESCRIPTION
- **Context**: Implements score persistence for the rewards system (closes #135).
- **Summary**: Adds schema and APIs to persist provider RSR scores with timestamps, efficient batch writes, and ON CONFLICT updates.

- **Changes**
  - DB: `0014_add_provider_rsr_scores.sql` table + indexes
  - Indexer: `rsr-score-storage.js` with:
    - `storeRSRScore(env, scoreData)`
    - `storeRSRScoresBatch(env, scoresData)`
    - `getLatestRSRScore(env, providerAddress)`
    - `getRSRScoresForProviders(env, providerAddresses, start?, end?)`
    - `getAllLatestRSRScores(env)`
    - `cleanupOldRSRScores(env, retentionDays)`
  - Tests: `indexer/test/rsr-score-storage.test.js`

- **Schema**
  - Table: `provider_rsr_scores(provider_address, score, calculated_at, calculation_period_start, calculation_period_end, total_requests, successful_requests, avg_response_time_ms, avg_ttfb_ms, avg_ttlb_ms, reliability_score, performance_score)`
  - PK: `(provider_address, calculated_at)`
  - Indexes: `(provider_address, calculated_at DESC)`, `(calculated_at DESC, provider_address)`

Closes #135