### PR TITLE
piece-retriever: fix test allowing null instead of result

### DIFF
--- a/piece-retriever/test/retriever.test.js
+++ b/piece-retriever/test/retriever.test.js
@@ -705,8 +705,7 @@ describe('piece-retriever.fetch', () => {
 
     const result = await env.DB.prepare(
       'SELECT * FROM retrieval_logs WHERE data_set_id IS NULL AND response_status = 404 and CACHE_MISS IS NULL and egress_bytes IS NULL',
-    )
-      .first()
+    ).first()
     expect(result).toBeTruthy()
   })
   it('does not log to retrieval_logs when payer address is invalid (400)', async () => {


### PR DESCRIPTION
`toBeDefined` only checks against `undefined`, and doesn't throw if the passed value is `null`. Here we obviously need to find an object. The query needed then to be modified, so the test was wrong there.

I noticed this looking at https://github.com/filbeam/worker/pull/381/files#diff-22346ddaa5f26927937c9426415f3f0ab1f5feadb7a91fca199679a164e4cadeR714, wondering why the test failed. 