### PR TITLE
Revert "piece-retrieval: add `X-Cache` header (#412)"

### DIFF
--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -156,10 +156,6 @@ export default {
         setContentSecurityPolicy(response)
         response.headers.set('X-Data-Set-ID', dataSetId)
         response.headers.set(
-          'X-Cache',
-          retrievalResult.cacheMiss ? 'MISS' : 'HIT',
-        )
-        response.headers.set(
           'Cache-Control',
           `public, max-age=${env.CLIENT_CACHE_TTL}`,
         )
@@ -210,10 +206,6 @@ export default {
       })
       setContentSecurityPolicy(response)
       response.headers.set('X-Data-Set-ID', dataSetId)
-      response.headers.set(
-        'X-Cache',
-        retrievalResult.cacheMiss ? 'MISS' : 'HIT',
-      )
       response.headers.set(
         'Cache-Control',
         `public, max-age=${env.CLIENT_CACHE_TTL}`,


### PR DESCRIPTION
This reverts commit 2e0c4e29406d7dee6939788678c817716083613b.

CF already exposes this in their own header