### PR TITLE
piece-retriever: add pick random SP

### DIFF
--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -212,7 +212,7 @@ export async function getStorageProviderAndValidatePayer(
     service_url: serviceUrl,
     cdn_egress_quota: cdnEgressQuota,
     cache_miss_egress_quota: cacheMissEgressQuota,
-  } = withSufficientCacheMissQuota[0]
+  } = pickRandom(withSufficientCacheMissQuota)
 
   // We need this assertion to supress TypeScript error. The compiler is not able to infer that
   // `withCDN.filter()` above returns only rows with `service_url` defined.
@@ -265,4 +265,13 @@ export async function updateDataSetStats(
       dataSetId,
     )
     .run()
+}
+
+/**
+ * @template T
+ * @param {T[]} arr
+ * @returns {T}
+ */
+function pickRandom(arr) {
+  return arr[Math.floor(Math.random() * arr.length)]
 }

--- a/piece-retriever/test/store.test.js
+++ b/piece-retriever/test/store.test.js
@@ -177,7 +177,7 @@ describe('getStorageProviderAndValidatePayer', () => {
     expect(result.serviceProviderId).toBe(APPROVED_SERVICE_PROVIDER_ID)
   })
 
-  it('returns the service provider first in the ordering when multiple service providers share the same pieceCid', async () => {
+  it('returns a random service provider when multiple service providers share the same pieceCid', async () => {
     const dataSetId1 = 'data-set-a'
     const dataSetId2 = 'data-set-b'
     const pieceCid = 'shared-piece-cid'
@@ -215,14 +215,20 @@ describe('getStorageProviderAndValidatePayer', () => {
       payerAddress,
     })
 
-    // Should return only the serviceProviderId1 which is the first in the ordering
-    const result = await getStorageProviderAndValidatePayer(
-      env,
-      payerAddress,
-      pieceCid,
-      true,
-    )
-    expect(result.serviceProviderId).toBe(serviceProviderId1)
+    const serviceProviderIdsReturned = new Set()
+    for (let i = 0; i < 100; i++) {
+      const result = await getStorageProviderAndValidatePayer(
+        env,
+        payerAddress,
+        pieceCid,
+        true,
+      )
+      serviceProviderIdsReturned.add(result.serviceProviderId)
+      if (serviceProviderIdsReturned.size === 2) {
+        return
+      }
+    }
+    throw new Error('Did not return 2 different SPs')
   })
 
   it('ignores owners that are not approved by Filecoin Warm Storage Service', async () => {


### PR DESCRIPTION
Since we will always have 2 SPs per data set, distribute traffic ~evenly.

Future steps:
1. Retry with different SP if picked one failed (this is kinda obvious)
2. Sort by remaining egress descending

Not so sure about the 2nd one, it can make it so SPs with higher egress budget can starve small SPs.