### PR TITLE
fix: Handle egress top-up before data set creation

### DIFF
--- a/indexer/lib/fwss-handlers.js
+++ b/indexer/lib/fwss-handlers.js
@@ -50,7 +50,7 @@ export async function handleFWSSDataSetCreated(
         with_ipfs_indexing
       )
       VALUES (?, ?, ?, ?, ?)
-      ON CONFLICT (id) DO NOTHING
+      ON CONFLICT DO NOTHING
     `,
   )
     .bind(

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -19,7 +19,7 @@
     "validator": "^13.15.15"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.10.4",
+    "@cloudflare/vitest-pool-workers": "^0.10.5",
     "@types/validator": "^13.15.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
       ],
       "devDependencies": {
         "@checkernetwork/prettier-config": "^1.0.1",
-        "@cloudflare/vitest-pool-workers": "^0.10.4",
+        "@cloudflare/vitest-pool-workers": "^0.10.5",
         "@npmcli/map-workspaces": "^5.0.1",
         "@types/node": "^22.19.0",
         "neostandard": "^0.12.1",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
         "vitest": "3.1.4",
-        "wrangler": "^4.45.3"
+        "wrangler": "^4.46.0"
       }
     },
     "bad-bits": {
@@ -47,7 +47,7 @@
         "validator": "^13.15.15"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.10.4",
+        "@cloudflare/vitest-pool-workers": "^0.10.5",
         "@types/validator": "^13.15.4"
       }
     },
@@ -98,18 +98,18 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.10.4.tgz",
-      "integrity": "sha512-PY9mexikRXEgJIXuFtr0ZWThbuBjq7VepC2sx8LpYizOLqoZ2NsUrJW+T+nojGxYNuzjulI8D14+mFezg7MhRQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.10.5.tgz",
+      "integrity": "sha512-jUVzEOQga7bbRT9zq5ktnn8TkfR+PbQGEhxWu9EUoaCdr33zwXxNOqLyp1i1VueN2CMK+a5zNP40LZVTNPQoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "birpc": "0.2.14",
         "cjs-module-lexer": "^1.2.3",
         "devalue": "^5.3.2",
-        "miniflare": "4.20251011.2",
+        "miniflare": "4.20251105.0",
         "semver": "^7.7.1",
-        "wrangler": "4.45.4",
+        "wrangler": "4.46.0",
         "zod": "^3.22.3"
       },
       "peerDependencies": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20251011.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251011.0.tgz",
-      "integrity": "sha512-0DirVP+Z82RtZLlK2B+VhLOkk+ShBqDYO/jhcRw4oVlp0TOvk3cOVZChrt3+y3NV8Y/PYgTEywzLKFSziK4wCg==",
+      "version": "1.20251105.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251105.0.tgz",
+      "integrity": "sha512-nztUP35wTtUKM+681dBWtUNSySNWELTV+LY43oWy7ZhK19/iBJPQoFY7xpvF7zy4qOOShtise259B65DS4/71Q==",
       "cpu": [
         "x64"
       ],
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20251011.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251011.0.tgz",
-      "integrity": "sha512-1WuFBGwZd15p4xssGN/48OE2oqokIuc51YvHvyNivyV8IYnAs3G9bJNGWth1X7iMDPe4g44pZrKhRnISS2+5dA==",
+      "version": "1.20251105.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251105.0.tgz",
+      "integrity": "sha512-WS/dvPYTW/+gs8s0UvDqDY7wcuIAg/hUpjrMNGepr+Mo38vMU39FYhJQOly99oJCXxMluQqAnRKg09b/9Gr+Rg==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20251011.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251011.0.tgz",
-      "integrity": "sha512-BccMiBzFlWZyFghIw2szanmYJrJGBGHomw2y/GV6pYXChFzMGZkeCEMfmCyJj29xczZXxcZmUVJxNy4eJxO8QA==",
+      "version": "1.20251105.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251105.0.tgz",
+      "integrity": "sha512-RdHRHo/hpjR6sNw529FkmslVSz/K3Pb1+i3fIoqUrHCrZOUYzFyz3nLeZh4EYaAhcztLWiSTwBv54bcl4sG3wA==",
       "cpu": [
         "x64"
       ],
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20251011.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251011.0.tgz",
-      "integrity": "sha512-79o/216lsbAbKEVDZYXR24ivEIE2ysDL9jvo0rDTkViLWju9dAp3CpyetglpJatbSi3uWBPKZBEOqN68zIjVsQ==",
+      "version": "1.20251105.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251105.0.tgz",
+      "integrity": "sha512-5zkxQCqLjwrqZVVJh92J2Drv6xifkP8kN2ltjHdwZQlVzfDW48d7tAtCm1ZooUv204ixvZFarusCfL+IRjExZg==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20251011.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251011.0.tgz",
-      "integrity": "sha512-RIXUQRchFdqEvaUqn1cXZXSKjpqMaSaVAkI5jNZ8XzAw/bw2bcdOVUtakrflgxDprltjFb0PTNtuss1FKtH9Jg==",
+      "version": "1.20251105.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251105.0.tgz",
+      "integrity": "sha512-6BpkfjBIbGR+4FBOcZGcWDLM0XQuoI6R9Dublj/BKf4pv0/xJ4zHdnaYUb5NIlC75L55Ouqw0CEJasoKlMjgnw==",
       "cpu": [
         "x64"
       ],
@@ -6213,9 +6213,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20251011.2",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251011.2.tgz",
-      "integrity": "sha512-5oAaz6lqZus4QFwzEJiNtgpjZR2TBVwBeIhOW33V4gu+l23EukpKja831tFIX2o6sOD/hqZmKZHplOrWl3YGtQ==",
+      "version": "4.20251105.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251105.0.tgz",
+      "integrity": "sha512-n+lCQbGLPjHFm5EKMohxCl+hLIki9rIlJSU9FkYKdJ62cGacetmTH5IgWUZhUFFM+NqhqZLOuWXTAsoZTm0hog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6227,7 +6227,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "7.14.0",
-        "workerd": "1.20251011.0",
+        "workerd": "1.20251105.0",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10",
         "zod": "3.22.3"
@@ -8636,9 +8636,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20251011.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251011.0.tgz",
-      "integrity": "sha512-Dq35TLPEJAw7BuYQMkN3p9rge34zWMU2Gnd4DSJFeVqld4+DAO2aPG7+We2dNIAyM97S8Y9BmHulbQ00E0HC7Q==",
+      "version": "1.20251105.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251105.0.tgz",
+      "integrity": "sha512-8D1UmsxrRr3Go7enbYCsYoiWeGn66u1WFNojPSgtjp7z8pV2cXskjr05vQ1OOzl7+rg1hDDofnCJqVwChMym8g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8649,17 +8649,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20251011.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20251011.0",
-        "@cloudflare/workerd-linux-64": "1.20251011.0",
-        "@cloudflare/workerd-linux-arm64": "1.20251011.0",
-        "@cloudflare/workerd-windows-64": "1.20251011.0"
+        "@cloudflare/workerd-darwin-64": "1.20251105.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20251105.0",
+        "@cloudflare/workerd-linux-64": "1.20251105.0",
+        "@cloudflare/workerd-linux-arm64": "1.20251105.0",
+        "@cloudflare/workerd-windows-64": "1.20251105.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.45.4",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.45.4.tgz",
-      "integrity": "sha512-niXT7B463wQi7WXIHjYK8txgWhuKQLrGmhjoR58SnPhlkq4wGjd3rFrkVyRc/O58clGTfs672BSGOph4XMoQKw==",
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.46.0.tgz",
+      "integrity": "sha512-WRROO7CL+MW/E44RMT4X7w32qPjufiPpGdey5D6H7iKzzVqfUkTRULxYBfWANiU1yGnsiCXQtu3Ap0G2TmohtA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -8667,10 +8667,10 @@
         "@cloudflare/unenv-preset": "2.7.9",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20251011.2",
+        "miniflare": "4.20251105.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20251011.0"
+        "workerd": "1.20251105.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -8683,7 +8683,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20251011.0"
+        "@cloudflare/workers-types": "^4.20251014.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -9329,7 +9329,7 @@
         "viem": "^2.38.6"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.10.4"
+        "@cloudflare/vitest-pool-workers": "^0.10.5"
       }
     },
     "piece-retriever": {
@@ -9355,7 +9355,7 @@
         "viem": "^2.38.6"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.10.4",
+        "@cloudflare/vitest-pool-workers": "^0.10.5",
         "@types/validator": "^13.15.4"
       }
     },
@@ -9367,7 +9367,7 @@
         "viem": "^2.38.6"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.10.4",
+        "@cloudflare/vitest-pool-workers": "^0.10.5",
         "@types/validator": "^13.15.4"
       }
     },
@@ -9378,7 +9378,7 @@
         "viem": "^2.38.6"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.10.4"
+        "@cloudflare/vitest-pool-workers": "^0.10.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "prettier": "@checkernetwork/prettier-config",
   "devDependencies": {
     "@checkernetwork/prettier-config": "^1.0.1",
-    "@cloudflare/vitest-pool-workers": "^0.10.4",
+    "@cloudflare/vitest-pool-workers": "^0.10.5",
     "@npmcli/map-workspaces": "^5.0.1",
     "@types/node": "^22.19.0",
     "neostandard": "^0.12.1",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "vitest": "3.1.4",
-    "wrangler": "^4.45.3"
+    "wrangler": "^4.46.0"
   }
 }

--- a/payment-settler/package.json
+++ b/payment-settler/package.json
@@ -18,6 +18,6 @@
     "viem": "^2.38.6"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.10.4"
+    "@cloudflare/vitest-pool-workers": "^0.10.5"
   }
 }

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -11,7 +11,7 @@ import {
   measureStreamedEgress,
 } from '../lib/retrieval.js'
 import {
-  getStorageProviderAndValidatePayer,
+  getRetrievalCandidatesAndValidatePayer,
   logRetrievalResult,
   updateDataSetStats,
 } from '../lib/store.js'
@@ -74,18 +74,17 @@ export default {
       // Timestamp to measure file retrieval performance (from cache and from SP)
       const fetchStartedAt = performance.now()
 
-      const [{ serviceProviderId, serviceUrl, dataSetId }, isBadBit] =
-        await Promise.all([
-          getStorageProviderAndValidatePayer(
-            env,
-            payerWalletAddress,
-            pieceCid,
-            env.ENFORCE_EGRESS_QUOTA,
-          ),
-          env.BAD_BITS_KV.get(`bad-bits:${await getBadBitsEntry(pieceCid)}`, {
-            type: 'json',
-          }),
-        ])
+      const [retrievalCandidates, isBadBit] = await Promise.all([
+        getRetrievalCandidatesAndValidatePayer(
+          env,
+          payerWalletAddress,
+          pieceCid,
+          env.ENFORCE_EGRESS_QUOTA,
+        ),
+        env.BAD_BITS_KV.get(`bad-bits:${await getBadBitsEntry(pieceCid)}`, {
+          type: 'json',
+        }),
+      ])
 
       httpAssert(
         !isBadBit,
@@ -94,23 +93,55 @@ export default {
       )
 
       httpAssert(
-        serviceProviderId,
-        404,
-        `Unsupported Service Provider: ${serviceProviderId}`,
+        retrievalCandidates.length > 0,
+        500,
+        'Service provider lookup failed',
       )
 
+      let retrievalCandidate
       let retrievalResult
+      const retrievalAttempts = []
 
-      try {
-        retrievalResult = await retrieveFile(
-          ctx,
-          serviceUrl,
-          pieceCid,
-          request,
-          env.ORIGIN_CACHE_TTL,
-          { signal: request.signal },
+      while (retrievalCandidates.length > 0) {
+        const retrievalCandidateIndex = Math.floor(
+          Math.random() * retrievalCandidates.length,
         )
-      } catch {}
+        retrievalCandidate = retrievalCandidates[retrievalCandidateIndex]
+        retrievalAttempts.push(retrievalCandidate)
+        retrievalCandidates.splice(retrievalCandidateIndex, 1)
+        console.log('Attempting retrieval', retrievalCandidate)
+        try {
+          retrievalResult = await retrieveFile(
+            ctx,
+            retrievalCandidate.serviceUrl,
+            pieceCid,
+            request,
+            env.ORIGIN_CACHE_TTL,
+            { signal: request.signal },
+          )
+          if (retrievalResult.response.ok) {
+            break
+          }
+          console.log(
+            `Retrieval attempt failed: HTTP ${retrievalResult.response.status}`,
+            {
+              retrievalCandidate,
+              willRetry: retrievalCandidates.length > 0,
+            },
+          )
+        } catch (err) {
+          const msg =
+            typeof err === 'object' && err !== null && 'message' in err
+              ? err.message
+              : String(err)
+          console.log(`Retrieval attempt failed: ${msg}`, {
+            retrievalCandidate,
+            willRetry: retrievalCandidates.length > 0,
+          })
+        }
+      }
+
+      httpAssert(retrievalCandidate, 500, 'should never happen')
 
       if (!retrievalResult || retrievalResult.response.status >= 500) {
         ctx.waitUntil(
@@ -120,16 +151,18 @@ export default {
             egressBytes: 0,
             requestCountryCode,
             timestamp: requestTimestamp,
-            dataSetId,
+            dataSetId: retrievalCandidate.dataSetId,
             botName,
           }),
         )
         const response = new Response(
-          `Service provider ${serviceProviderId} is unavailable${retrievalResult ? ` at ${retrievalResult.url}` : ''}`,
+          `No available service provider found. Attempted: ${retrievalAttempts.map((a) => `ID=${a.serviceProviderId} (Service URL=${a.serviceUrl})`).join(', ')}`,
           {
             status: 502,
             headers: new Headers({
-              'X-Data-Set-ID': dataSetId,
+              'X-Data-Set-ID': retrievalAttempts
+                .map((a) => a.dataSetId)
+                .join(','),
             }),
           },
         )
@@ -148,7 +181,7 @@ export default {
             egressBytes: 0,
             requestCountryCode,
             timestamp: requestTimestamp,
-            dataSetId,
+            dataSetId: retrievalCandidate.dataSetId,
             botName,
           }),
         )
@@ -157,7 +190,7 @@ export default {
           retrievalResult.response,
         )
         setContentSecurityPolicy(response)
-        response.headers.set('X-Data-Set-ID', dataSetId)
+        response.headers.set('X-Data-Set-ID', retrievalCandidate.dataSetId)
         response.headers.set(
           'Cache-Control',
           `public, max-age=${env.CLIENT_CACHE_TTL}`,
@@ -188,12 +221,12 @@ export default {
               fetchTtlb: lastByteFetchedAt - fetchStartedAt,
               workerTtfb: firstByteAt - workerStartedAt,
             },
-            dataSetId,
+            dataSetId: retrievalCandidate.dataSetId,
             botName,
           })
 
           await updateDataSetStats(env, {
-            dataSetId,
+            dataSetId: retrievalCandidate.dataSetId,
             egressBytes,
             cacheMiss: retrievalResult.cacheMiss,
             enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
@@ -208,7 +241,7 @@ export default {
         headers: retrievalResult.response.headers,
       })
       setContentSecurityPolicy(response)
-      response.headers.set('X-Data-Set-ID', dataSetId)
+      response.headers.set('X-Data-Set-ID', retrievalCandidate.dataSetId)
       response.headers.set(
         'Cache-Control',
         `public, max-age=${env.CLIENT_CACHE_TTL}`,

--- a/piece-retriever/test/retriever.test.js
+++ b/piece-retriever/test/retriever.test.js
@@ -933,7 +933,9 @@ describe('piece-retriever.fetch', () => {
     })
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(502)
-    expect(await res.text()).toMatch(/^Service provider \d+ is unavailable at /)
+    expect(await res.text()).toMatch(
+      /^No available service provider found. Attempted: ID=/,
+    )
     expect(res.headers.get('X-Data-Set-ID')).toBe(String(dataSetId))
 
     const result = await env.DB.prepare(
@@ -1063,7 +1065,9 @@ describe('piece-retriever.fetch', () => {
     })
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(502)
-    expect(await res.text()).toMatch(/^Service provider \d+ is unavailable$/)
+    expect(await res.text()).toMatch(
+      /^No available service provider found. Attempted: ID=/,
+    )
     expect(res.headers.get('X-Data-Set-ID')).toBe(String(dataSetId))
   })
 })

--- a/piece-retriever/test/store.test.js
+++ b/piece-retriever/test/store.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeAll, expect } from 'vitest'
 import {
   logRetrievalResult,
-  getStorageProviderAndValidatePayer,
+  getRetrievalCandidatesAndValidatePayer,
   updateDataSetStats,
 } from '../lib/store.js'
 import { env } from 'cloudflare:test'
@@ -48,7 +48,7 @@ describe('logRetrievalResult', () => {
   })
 })
 
-describe('getStorageProviderAndValidatePayer', () => {
+describe('getRetrievalCandidatesAndValidatePayer', () => {
   const APPROVED_SERVICE_PROVIDER_ID = '20'
   beforeAll(async () => {
     await withApprovedProvider(env, {
@@ -73,19 +73,21 @@ describe('getStorageProviderAndValidatePayer', () => {
       pieceId: 'piece-1',
     })
 
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       true,
     )
-    expect(result.serviceProviderId).toBe(APPROVED_SERVICE_PROVIDER_ID)
+    expect(results).toMatchObject([
+      { serviceProviderId: APPROVED_SERVICE_PROVIDER_ID },
+    ])
   })
 
   it('throws error if pieceCid not found', async () => {
     const payerAddress = '0x1234567890abcdef1234567890abcdef12345678'
     await expect(
-      getStorageProviderAndValidatePayer(
+      getRetrievalCandidatesAndValidatePayer(
         env,
         payerAddress,
         'nonexistent-cid',
@@ -102,7 +104,7 @@ describe('getStorageProviderAndValidatePayer', () => {
     await withPiece(env, { pieceId: 'piece-no-sp', dataSetId, pieceCid })
 
     await expect(
-      getStorageProviderAndValidatePayer(env, payerAddress, pieceCid, true),
+      getRetrievalCandidatesAndValidatePayer(env, payerAddress, pieceCid, true),
     ).rejects.toThrow(/no associated service provider/)
   })
 
@@ -124,7 +126,7 @@ describe('getStorageProviderAndValidatePayer', () => {
     })
 
     await expect(
-      getStorageProviderAndValidatePayer(env, payerAddress, pieceCid, true),
+      getRetrievalCandidatesAndValidatePayer(env, payerAddress, pieceCid, true),
     ).rejects.toThrow(
       /There is no Filecoin Warm Storage Service deal for payer/,
     )
@@ -148,11 +150,11 @@ describe('getStorageProviderAndValidatePayer', () => {
     })
 
     await expect(
-      getStorageProviderAndValidatePayer(env, payerAddress, pieceCid, true),
+      getRetrievalCandidatesAndValidatePayer(env, payerAddress, pieceCid, true),
     ).rejects.toThrow(/withCDN=false/)
   })
 
-  it('returns serviceProviderId for approved service provider', async () => {
+  it('returns serviceProviderId for approved service providers', async () => {
     const pieceCid = 'cid-approved'
     const dataSetId = 'data-set-approved'
     const payerAddress = '0xabcdef1234567890abcdef1234567890abcdef12'
@@ -168,16 +170,18 @@ describe('getStorageProviderAndValidatePayer', () => {
       pieceCid,
     })
 
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       true,
     )
-    expect(result.serviceProviderId).toBe(APPROVED_SERVICE_PROVIDER_ID)
+    expect(results).toMatchObject([
+      { serviceProviderId: APPROVED_SERVICE_PROVIDER_ID },
+    ])
   })
 
-  it('returns a random service provider when multiple service providers share the same pieceCid', async () => {
+  it('returns multiple service providers when they share the same pieceCid', async () => {
     const dataSetId1 = 'data-set-a'
     const dataSetId2 = 'data-set-b'
     const pieceCid = 'shared-piece-cid'
@@ -215,20 +219,17 @@ describe('getStorageProviderAndValidatePayer', () => {
       payerAddress,
     })
 
-    const serviceProviderIdsReturned = new Set()
-    for (let i = 0; i < 100; i++) {
-      const result = await getStorageProviderAndValidatePayer(
-        env,
-        payerAddress,
-        pieceCid,
-        true,
-      )
-      serviceProviderIdsReturned.add(result.serviceProviderId)
-      if (serviceProviderIdsReturned.size === 2) {
-        return
-      }
-    }
-    throw new Error('Did not return 2 different SPs')
+    const results = await getRetrievalCandidatesAndValidatePayer(
+      env,
+      payerAddress,
+      pieceCid,
+      true,
+    )
+
+    expect(results).toMatchObject([
+      { serviceProviderId: serviceProviderId1 },
+      { serviceProviderId: serviceProviderId2 },
+    ])
   })
 
   it('ignores owners that are not approved by Filecoin Warm Storage Service', async () => {
@@ -268,19 +269,21 @@ describe('getStorageProviderAndValidatePayer', () => {
     })
 
     // Should return service provider 1 because service provider 2 is not approved
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       true,
     )
-    expect(result).toEqual({
-      dataSetId: dataSetId1,
-      serviceProviderId: serviceProviderId1.toLowerCase(),
-      serviceUrl: 'https://pdp-provider-1.xyz',
-      cdnEgressQuota: 100n,
-      cacheMissEgressQuota: 100n,
-    })
+    expect(results).toMatchObject([
+      {
+        dataSetId: dataSetId1,
+        serviceProviderId: serviceProviderId1.toLowerCase(),
+        serviceUrl: 'https://pdp-provider-1.xyz',
+        cdnEgressQuota: 100n,
+        cacheMissEgressQuota: 100n,
+      },
+    ])
   })
 })
 
@@ -311,7 +314,7 @@ describe('Egress Quota Management', () => {
     })
 
     await expect(
-      getStorageProviderAndValidatePayer(env, payerAddress, pieceCid, true),
+      getRetrievalCandidatesAndValidatePayer(env, payerAddress, pieceCid, true),
     ).rejects.toThrow(/CDN egress quota exhausted for payer/)
   })
 
@@ -332,7 +335,7 @@ describe('Egress Quota Management', () => {
     })
 
     await expect(
-      getStorageProviderAndValidatePayer(env, payerAddress, pieceCid, true),
+      getRetrievalCandidatesAndValidatePayer(env, payerAddress, pieceCid, true),
     ).rejects.toThrow(/Cache miss egress quota exhausted for payer/)
   })
 
@@ -352,19 +355,21 @@ describe('Egress Quota Management', () => {
       pieceId: 'piece-sufficient',
     })
 
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       true,
     )
-    expect(result).toStrictEqual({
-      dataSetId,
-      serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
-      serviceUrl: 'https://quota-test-provider.xyz',
-      cdnEgressQuota: 1n,
-      cacheMissEgressQuota: 1n,
-    })
+    expect(results).toMatchObject([
+      {
+        dataSetId,
+        serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
+        serviceUrl: 'https://quota-test-provider.xyz',
+        cdnEgressQuota: 1n,
+        cacheMissEgressQuota: 1n,
+      },
+    ])
   })
 
   it('correctly decrements CDN quota on cache hit', async () => {
@@ -523,7 +528,7 @@ describe('Egress Quota Management', () => {
 
     // Should return 402 error when quotas are null
     await expect(
-      getStorageProviderAndValidatePayer(env, payerAddress, pieceCid, true),
+      getRetrievalCandidatesAndValidatePayer(env, payerAddress, pieceCid, true),
     ).rejects.toThrow(/CDN egress quota exhausted for payer/)
   })
 
@@ -545,19 +550,21 @@ describe('Egress Quota Management', () => {
     })
 
     // Quota of exactly 100 should be sufficient (> 0)
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       true,
     )
-    expect(result).toStrictEqual({
-      dataSetId,
-      serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
-      serviceUrl: 'https://quota-test-provider.xyz',
-      cdnEgressQuota: 100n,
-      cacheMissEgressQuota: 100n,
-    })
+    expect(results).toMatchObject([
+      {
+        dataSetId,
+        serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
+        serviceUrl: 'https://quota-test-provider.xyz',
+        cdnEgressQuota: 100n,
+        cacheMissEgressQuota: 100n,
+      },
+    ])
 
     // Decrement by exact amount should result in 0
     await updateDataSetStats(env, {
@@ -593,19 +600,21 @@ describe('Egress Quota Management', () => {
       pieceId: 'piece-no-enforce-cdn-exhausted',
     })
 
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       false,
     )
-    expect(result).toStrictEqual({
-      dataSetId,
-      serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
-      serviceUrl: 'https://quota-test-provider.xyz',
-      cdnEgressQuota: 0n,
-      cacheMissEgressQuota: 1n,
-    })
+    expect(results).toMatchObject([
+      {
+        dataSetId,
+        serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
+        serviceUrl: 'https://quota-test-provider.xyz',
+        cdnEgressQuota: 0n,
+        cacheMissEgressQuota: 1n,
+      },
+    ])
   })
 
   it('allows retrieval when quota enforcement is disabled and cache-miss quota is exhausted', async () => {
@@ -624,19 +633,21 @@ describe('Egress Quota Management', () => {
       pieceId: 'piece-no-enforce-cache-miss-exhausted',
     })
 
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       false,
     )
-    expect(result).toStrictEqual({
-      dataSetId,
-      serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
-      serviceUrl: 'https://quota-test-provider.xyz',
-      cdnEgressQuota: 1n,
-      cacheMissEgressQuota: 0n,
-    })
+    expect(results).toMatchObject([
+      {
+        dataSetId,
+        serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
+        serviceUrl: 'https://quota-test-provider.xyz',
+        cdnEgressQuota: 1n,
+        cacheMissEgressQuota: 0n,
+      },
+    ])
   })
 
   it('allows retrieval when quota enforcement is disabled and both quotas are exhausted', async () => {
@@ -655,19 +666,21 @@ describe('Egress Quota Management', () => {
       pieceId: 'piece-no-enforce-both-exhausted',
     })
 
-    const result = await getStorageProviderAndValidatePayer(
+    const results = await getRetrievalCandidatesAndValidatePayer(
       env,
       payerAddress,
       pieceCid,
       false,
     )
-    expect(result).toStrictEqual({
-      dataSetId,
-      serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
-      serviceUrl: 'https://quota-test-provider.xyz',
-      cdnEgressQuota: 0n,
-      cacheMissEgressQuota: 0n,
-    })
+    expect(results).toMatchObject([
+      {
+        dataSetId,
+        serviceProviderId: APPROVED_SERVICE_PROVIDER_ID,
+        serviceUrl: 'https://quota-test-provider.xyz',
+        cdnEgressQuota: 0n,
+        cacheMissEgressQuota: 0n,
+      },
+    ])
   })
 })
 

--- a/terminator/package.json
+++ b/terminator/package.json
@@ -18,7 +18,7 @@
     "viem": "^2.38.6"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.10.4",
+    "@cloudflare/vitest-pool-workers": "^0.10.5",
     "@types/validator": "^13.15.4"
   }
 }

--- a/usage-reporter/package.json
+++ b/usage-reporter/package.json
@@ -18,7 +18,7 @@
     "viem": "^2.38.6"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.10.4",
+    "@cloudflare/vitest-pool-workers": "^0.10.5",
     "@types/validator": "^13.15.4"
   }
 }

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -14,6 +14,6 @@
     "viem": "^2.38.6"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.10.4"
+    "@cloudflare/vitest-pool-workers": "^0.10.5"
   }
 }


### PR DESCRIPTION
Fixes `/fwss/cdn-payment-rails-topped-up` handler, where the `CDNPaymentRailsToppedUp` event is emitted before the `DataSetCreated` event. 

## Changelog:

- Fixes `/fwss/cdn-payment-rails-topped-up` handler to handle  `CDNPaymentRailsToppedUp` event if it is emitted before the `DataSetCreated` event. 
- Cleans up existing and adds new tests