### PR TITLE
chore: Enable ENFORCE_EGRESS_QUOTA

### DIFF
--- a/piece-retriever/wrangler.toml
+++ b/piece-retriever/wrangler.toml
@@ -31,7 +31,7 @@ ENVIRONMENT = "calibration "
 ORIGIN_CACHE_TTL = 86400
 CLIENT_CACHE_TTL = 31536000
 DNS_ROOT = ".calibration.filbeam.io"
-ENFORCE_EGRESS_QUOTA = false
+ENFORCE_EGRESS_QUOTA = true
 
 [[env.calibration.d1_databases]]
 binding = "DB"
@@ -47,7 +47,7 @@ ENVIRONMENT = "mainnet"
 ORIGIN_CACHE_TTL = 86400
 CLIENT_CACHE_TTL = 31536000
 DNS_ROOT = ".filbeam.io"
-ENFORCE_EGRESS_QUOTA = false
+ENFORCE_EGRESS_QUOTA = true
 
 [[env.mainnet.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
Re-enables egress quota enforcement after https://github.com/filbeam/worker/commit/e664eb6a69964efc5160009fb10b89c59cfdc883 hotfix.

Related to https://github.com/filbeam/worker/pull/448 and https://github.com/filbeam/worker/pull/435