### PR TITLE
fix: usage-reporter FilBeamOperator ABI

### DIFF
--- a/usage-reporter/lib/FilBeamOperator.abi.json
+++ b/usage-reporter/lib/FilBeamOperator.abi.json
@@ -24,6 +24,7 @@
     ],
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "recordUsageRollups"
+    "name": "recordUsageRollups",
+    "outputs": []
   }
 ]


### PR DESCRIPTION
Adds missing outputs definition to the usage-reporter FilBeamOperator ABI