### PR TITLE
fix: workflow id too long

### DIFF
--- a/payment-settler/bin/payment-settler.js
+++ b/payment-settler/bin/payment-settler.js
@@ -55,7 +55,7 @@ export default {
 
       // Start transaction monitor workflow
       await env.TRANSACTION_MONITOR_WORKFLOW.create({
-        id: `settlement-tx-monitor-${hash}-${Date.now()}`,
+        id: `payment-settler-${hash}-${Date.now()}`,
         params: {
           transactionHash: hash,
           metadata: {

--- a/payment-settler/lib/queue-handlers.js
+++ b/payment-settler/lib/queue-handlers.js
@@ -110,7 +110,7 @@ export async function handleTransactionRetryQueueMessage(
 
     // Start transaction monitor workflow
     await env.TRANSACTION_MONITOR_WORKFLOW.create({
-      id: `settlement-tx-monitor-${retryHash}-${Date.now()}`,
+      id: `payment-settler-${retryHash}-${Date.now()}`,
       params: {
         transactionHash: retryHash,
         metadata: {

--- a/payment-settler/test/worker.test.js
+++ b/payment-settler/test/worker.test.js
@@ -103,9 +103,7 @@ describe('payment settler scheduled handler', () => {
     ])
 
     expect(mockWorkflow.create).toHaveBeenCalledWith({
-      id: expect.stringMatching(
-        /^settlement-tx-monitor-0xMockTransactionHash-\d+$/,
-      ),
+      id: expect.stringMatching(/^payment-settler-0xMockTransactionHash-\d+$/),
       params: {
         transactionHash: '0xMockTransactionHash',
         metadata: {

--- a/usage-reporter/bin/usage-reporter.js
+++ b/usage-reporter/bin/usage-reporter.js
@@ -113,7 +113,7 @@ export default {
 
       // Start transaction monitor workflow
       await env.TRANSACTION_MONITOR_WORKFLOW.create({
-        id: `usage-report-tx-monitor-${hash}-${Date.now()}`,
+        id: `usage-reporter-${hash}-${Date.now()}`,
         params: {
           transactionHash: hash,
           metadata: {

--- a/usage-reporter/lib/queue-handlers.js
+++ b/usage-reporter/lib/queue-handlers.js
@@ -171,7 +171,7 @@ export async function handleTransactionRetryQueueMessage(
 
     // Start a new transaction monitor workflow for the retry transaction
     await env.TRANSACTION_MONITOR_WORKFLOW.create({
-      id: `usage-report-tx-monitor-${retryHash}-${Date.now()}`,
+      id: `usage-reporter-${retryHash}-${Date.now()}`,
       params: {
         transactionHash: retryHash,
         metadata: {

--- a/workflows/lib/transaction-monitor-workflow.js
+++ b/workflows/lib/transaction-monitor-workflow.js
@@ -13,9 +13,9 @@ import { getChainClient } from './chain.js'
  *
  * @example // With confirmation and retry data await
  * env.TRANSACTION_MONITOR_WORKFLOW.create({ id:
- * `usage-report-tx-monitor-${hash}-${Date.now()}`, params: { transactionHash:
- * hash, metadata: { onSuccess: 'transaction-confirmed', successData: {
- * upToTimestamp }, retryData: { upToTimestamp } } } })
+ * `usage-reporter-${hash}-${Date.now()}`, params: { transactionHash: hash,
+ * metadata: { onSuccess: 'transaction-confirmed', successData: { upToTimestamp
+ * }, retryData: { upToTimestamp } } } })
  */
 export class TransactionMonitorWorkflow extends WorkflowEntrypoint {
   /**


### PR DESCRIPTION
Fixes errors caused workflow ID being too long. Workflow ID is capped at a maximum of 100 characters. These errors are emitted during workflow creation by the [workflow validation function](https://github.com/cloudflare/workers-sdk/blob/4937e85a0df6ffd86b1730623012dcb9ee31127c/packages/workflows-shared/src/lib/validators.ts#L27-L38). 