### PR TITLE
fix: Pass single array to settleCDNPaymentRails

### DIFF
--- a/payment-settler/bin/payment-settler.js
+++ b/payment-settler/bin/payment-settler.js
@@ -46,7 +46,7 @@ export default {
         abi: filbeamAbi,
         address: env.FILBEAM_OPERATOR_CONTRACT_ADDRESS,
         functionName: 'settleCDNPaymentRails',
-        args: dataSetIds.map((id) => BigInt(id)),
+        args: [dataSetIds.map((id) => BigInt(id))],
       })
 
       const hash = await walletClient.writeContract(request)

--- a/payment-settler/test/worker.test.js
+++ b/payment-settler/test/worker.test.js
@@ -87,7 +87,7 @@ describe('payment settler scheduled handler', () => {
         abi: expect.any(Array),
         address: '0xTestContractAddress',
         functionName: 'settleCDNPaymentRails',
-        args: [expect.any(BigInt), expect.any(BigInt)],
+        args: [[expect.any(BigInt), expect.any(BigInt)]],
       },
     ])
 
@@ -97,7 +97,7 @@ describe('payment settler scheduled handler', () => {
         abi: expect.any(Array),
         address: '0xTestContractAddress',
         functionName: 'settleCDNPaymentRails',
-        args: [expect.any(BigInt), expect.any(BigInt)],
+        args: [[expect.any(BigInt), expect.any(BigInt)]],
         mockedRequest: true,
       },
     ])
@@ -161,7 +161,7 @@ describe('payment settler scheduled handler', () => {
         abi: expect.any(Array),
         address: '0xTestContractAddress',
         functionName: 'settleCDNPaymentRails',
-        args: [expect.any(BigInt), expect.any(BigInt)],
+        args: [[expect.any(BigInt), expect.any(BigInt)]],
       },
     ])
     expect(writeContractCalls).toStrictEqual([
@@ -170,7 +170,7 @@ describe('payment settler scheduled handler', () => {
         abi: expect.any(Array),
         address: '0xTestContractAddress',
         functionName: 'settleCDNPaymentRails',
-        args: [expect.any(BigInt), expect.any(BigInt)],
+        args: [[expect.any(BigInt), expect.any(BigInt)]],
         mockedRequest: true,
       },
     ])


### PR DESCRIPTION
Fixes `settleCDNPaymentRails` by passing a BigInt array as single argument instead of passing `n` number of arguments where `n = dataSetIds.length`. 