### PR TITLE
refactor retrieval tail worker

### DIFF
--- a/piece-retriever/wrangler.toml
+++ b/piece-retriever/wrangler.toml
@@ -3,6 +3,7 @@ main = "bin/piece-retriever.js"
 compatibility_date = "2025-09-08"
 compatibility_flags = ["nodejs_compat"]
 logpush = true
+tail_consumers = [{service = "retrieval"}]
 
 [[d1_databases]]
 binding = "DB"

--- a/retrieval/index.js
+++ b/retrieval/index.js
@@ -1,3 +1,5 @@
+import { logRetrievalResult, updateDataSetStats } from './lib/stats.js'
+
 export * from './lib/address.js'
 export * from './lib/bad-bits-util.js'
 export * from './lib/content-security-policy.js'
@@ -5,12 +7,41 @@ export * from './lib/http-assert.js'
 export * from './lib/stats.js'
 
 export default {
-  /**
-   * @param {Request} _request
-   * @param {Env} _env
-   * @param {ExecutionContext} _ctx
-   */
-  async fetch(_request, _env, _ctx) {
+  async fetch() {
     return new Response('Not Implemented', { status: 501 })
+  },
+
+  /**
+   * @param {TailEvent[]} events
+   * @param {Env} env
+   */
+  async tail(events, env) {
+    for (const event of events) {
+      const meta = new Map()
+      for (const messageData of event.diagnosticsChannelEvents) {
+        meta.set(messageData.channel, messageData.message)
+      }
+      await logRetrievalResult(env, {
+        cacheMiss: meta.get('cacheMiss') ?? null,
+        responseStatus: event.event.response.status,
+        egressBytes: meta.get('egressBytes') ?? null,
+        requestCountryCode: meta.get('requestCountryCode'),
+        timestamp: event.eventTimestamp,
+        dataSetId: meta.get('dataSetId'),
+        botName: meta.get('botName'),
+        performanceStats: meta.get('performanceStats'),
+      })
+      if (
+        event.eventPhase.response.status < 300 &&
+        meta.get('egressBytes') > 0
+      ) {
+        await updateDataSetStats(env, {
+          dataSetId: meta.get('dataSetId'),
+          egressBytes: meta.get('egressBytes'),
+          cacheMiss: meta.get('cacheMiss'),
+          enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
+        })
+      }
+    }
   },
 }


### PR DESCRIPTION
Use tail workers to submit retrieval results, across all retrieval workers.

- This simplifies the code a lot
- I need to figure out how to test things
- Diagnostics channel are the way to forward meta data to the tail worker
- The TS bindings we're using don't match CF documentation of the feature.