### PR TITLE
perf: use `node:crypto` for sync SHA2 hashing

### DIFF
--- a/piece-retriever/wrangler.toml
+++ b/piece-retriever/wrangler.toml
@@ -57,3 +57,6 @@ database_id = "e8de6418-2cb7-4413-9ba0-a9c8aacf9a66"
 [[env.mainnet.kv_namespaces]]
 binding = "BAD_BITS_KV"
 id = "7b03c39d53a041fdbe973c20285e16e9"
+
+[alias]
+"sync-multihash-sha2/sha256" = "../node_modules/sync-multihash-sha2/src/sha256/node.js"


### PR DESCRIPTION
This is a follow-up for https://github.com/filbeam/worker/issues/305

Configure wrangler's bundler to load the Node.js version of sync sha2 instead of the pure-JavaScript version for browsers.

When testing this locally on my machine, I observed the following download speeds reported by curl:
- Old version: 719 KB/s
- New version: 3153 KB/s
- Content verification disabled: 12.9 MB/s