### PR TITLE
fix: don't alert when _meta is missing

### DIFF
--- a/indexer/bin/indexer.js
+++ b/indexer/bin/indexer.js
@@ -336,7 +336,10 @@ export default {
       alerts.push(
         `Can't access subgraph: ${subgraph.reason.stack ?? subgraph.reason.message ?? subgraph.reason}`,
       )
-    } else if (typeof subgraph.value?._meta !== 'object' || subgraph.value?._meta === null) {
+    } else if (
+      typeof subgraph.value?._meta !== 'object' ||
+      subgraph.value?._meta === null
+    ) {
       console.warn(`Unexpected subgraph response: ${subgraph.value}`)
     } else if (subgraph.value._meta.hasIndexingErrors) {
       alerts.push('Goldsky has indexing errors')


### PR DESCRIPTION
Goldsky occassionaly returns an HTTP response missing the quried `_meta` field. This patch fixes our indexer to not trigger any alerts in such case, as the problem is not actionable.

Note: Since we don't have any Grafana-based chart visualising Goldsky status yet, there is no easy way how to create an alert to let us know when we keep receiving Goldsky responses with missing `_meta` field for an extended period of time. I feel fixing that is beyond my goal of getting rid of a false-positive alarm.
