### PR TITLE
fix: don't cache error cache-miss responses

### DIFF
--- a/piece-retriever/lib/retrieval.js
+++ b/piece-retriever/lib/retrieval.js
@@ -42,8 +42,12 @@ export async function retrieveFile(
   } else {
     response = await fetch(url, {
       cf: {
+        cacheTtlByStatus: {
+          '200-299': cacheTtl,
+          404: 0,
+          '500-599': 0,
+        },
         cacheEverything: true,
-        cacheTtl,
       },
       signal,
     })

--- a/piece-retriever/test/retrieval.test.js
+++ b/piece-retriever/test/retrieval.test.js
@@ -61,8 +61,12 @@ describe('retrieveFile', () => {
     await retrieveFile(ctx, baseUrl, pieceCid, new Request(baseUrl))
     await waitOnExecutionContext(ctx)
     expect(requestedCfOptions).toEqual({
+      cacheTtlByStatus: {
+        '200-299': 86400,
+        404: 0,
+        '500-599': 0,
+      },
       cacheEverything: true,
-      cacheTtl: 86400,
     })
   })
 
@@ -76,8 +80,12 @@ describe('retrieveFile', () => {
     await retrieveFile(ctx, baseUrl, pieceCid, new Request(baseUrl), 1234)
     await waitOnExecutionContext(ctx)
     expect(requestedCfOptions).toEqual({
+      cacheTtlByStatus: {
+        '200-299': 1234,
+        404: 0,
+        '500-599': 0,
+      },
       cacheEverything: true,
-      cacheTtl: 1234,
     })
   })
 


### PR DESCRIPTION
This is a follow-up for https://github.com/filbeam/worker/pull/537, which performed a partial revert of https://github.com/filbeam/worker/pull/315 and did not restore the full `cf` fetch config.
