### PR TITLE
DRY: share the retrieval request-handling flow (Tier 2)

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -5,9 +5,10 @@ import {
   setRetrievalResponseHeaders,
   isCidDenied,
   BAD_BITS_DENIED_MESSAGE,
-  updateDataSetStats,
   logRetrievalResult,
-  getErrorHttpStatusMessage,
+  recordRetrieval,
+  logRetrievalError,
+  redirectLegacyDomain,
   handleError,
 } from '@filbeam/retrieval'
 
@@ -73,12 +74,8 @@ export default {
       return handleDnsRootRequest(request, env)
     }
 
-    if (URL.parse(request.url)?.hostname.endsWith('filcdn.io')) {
-      return Response.redirect(
-        request.url.replace('filcdn.io', 'filbeam.io'),
-        301,
-      )
-    }
+    const legacyRedirect = redirectLegacyDomain(request)
+    if (legacyRedirect) return legacyRedirect
 
     const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
@@ -231,7 +228,7 @@ export default {
           // unchanged (e.g. `?format=car`), the two values are equal.
           const cacheMissEgressBytes = originEgressBytes ?? egressBytes
 
-          await logRetrievalResult(env, {
+          await recordRetrieval(env, {
             cacheMiss,
             cacheMissResponseValid: null,
             responseStatus: originResponse.status,
@@ -246,13 +243,6 @@ export default {
             },
             dataSetId: candidate.dataSetId,
             botName,
-          })
-
-          await updateDataSetStats(env, {
-            dataSetId: candidate.dataSetId,
-            egressBytes,
-            cacheMissEgressBytes,
-            cacheMiss,
             enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
           })
         })(),
@@ -272,20 +262,11 @@ export default {
 
       return response
     } catch (error) {
-      const { status } = getErrorHttpStatusMessage(error)
-
-      ctx.waitUntil(
-        logRetrievalResult(env, {
-          cacheMiss: null,
-          cacheMissResponseValid: null,
-          responseStatus: status,
-          egressBytes: null,
-          requestCountryCode,
-          timestamp: requestTimestamp,
-          dataSetId: null,
-          botName,
-        }),
-      )
+      logRetrievalError(env, ctx, error, {
+        requestCountryCode,
+        timestamp: requestTimestamp,
+        botName,
+      })
 
       throw error
     }

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -5,9 +5,10 @@ import {
   setRetrievalResponseHeaders,
   isCidDenied,
   BAD_BITS_DENIED_MESSAGE,
-  updateDataSetStats,
   logRetrievalResult,
-  getErrorHttpStatusMessage,
+  recordRetrieval,
+  logRetrievalError,
+  redirectLegacyDomain,
   handleError,
 } from '@filbeam/retrieval'
 
@@ -55,12 +56,8 @@ export default {
     if (URL.parse(request.url)?.pathname === '/') {
       return Response.redirect('https://filbeam.com/', 302)
     }
-    if (URL.parse(request.url)?.hostname.endsWith('filcdn.io')) {
-      return Response.redirect(
-        request.url.replace('filcdn.io', 'filbeam.io'),
-        301,
-      )
-    }
+    const legacyRedirect = redirectLegacyDomain(request)
+    if (legacyRedirect) return legacyRedirect
 
     const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
@@ -282,7 +279,7 @@ export default {
               )
             }
 
-            await logRetrievalResult(env, {
+            await recordRetrieval(env, {
               cacheMiss: retrievalResult.cacheMiss,
               cacheMissResponseValid,
               responseStatus: retrievalResult.response.status,
@@ -296,13 +293,6 @@ export default {
               },
               dataSetId: retrievalCandidate.dataSetId,
               botName,
-            })
-
-            await updateDataSetStats(env, {
-              dataSetId: retrievalCandidate.dataSetId,
-              egressBytes,
-              cacheMiss: retrievalResult.cacheMiss,
-              cacheMissResponseValid,
               enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
             })
           } catch (err) {
@@ -336,20 +326,11 @@ export default {
       })
       return response
     } catch (error) {
-      const { status } = getErrorHttpStatusMessage(error)
-
-      ctx.waitUntil(
-        logRetrievalResult(env, {
-          cacheMiss: null,
-          cacheMissResponseValid: null,
-          responseStatus: status,
-          egressBytes: null,
-          requestCountryCode,
-          timestamp: requestTimestamp,
-          dataSetId: null,
-          botName,
-        }),
-      )
+      logRetrievalError(env, ctx, error, {
+        requestCountryCode,
+        timestamp: requestTimestamp,
+        botName,
+      })
 
       throw error
     }

--- a/retrieval/index.js
+++ b/retrieval/index.js
@@ -5,6 +5,7 @@ export * from './lib/content-security-policy.js'
 export * from './lib/http-assert.js'
 export * from './lib/http-error.js'
 export * from './lib/origin-cache.js'
+export * from './lib/redirect.js'
 export * from './lib/response-headers.js'
 export * from './lib/stats.js'
 

--- a/retrieval/lib/redirect.js
+++ b/retrieval/lib/redirect.js
@@ -1,0 +1,16 @@
+/**
+ * Redirects legacy `*.filcdn.io` requests to the equivalent `*.filbeam.io` URL
+ * with a 301.
+ *
+ * @param {Request} request
+ * @returns {Response | undefined} A redirect response, or `undefined` when the
+ *   request is not for a legacy domain.
+ */
+export function redirectLegacyDomain(request) {
+  if (URL.parse(request.url)?.hostname.endsWith('filcdn.io')) {
+    return Response.redirect(
+      request.url.replace('filcdn.io', 'filbeam.io'),
+      301,
+    )
+  }
+}

--- a/retrieval/lib/stats.js
+++ b/retrieval/lib/stats.js
@@ -1,3 +1,5 @@
+import { getErrorHttpStatusMessage } from './http-error.js'
+
 /**
  * @param {{ DB: D1Database }} env - Worker environment (contains D1 binding).
  * @param {object} params - Parameters for the data set update.
@@ -12,7 +14,7 @@
  *   CAR that is larger than the raw bytes served to the client.
  * @param {boolean} params.cacheMiss - Whether this was a cache miss (true) or
  *   cache hit (false).
- * @param {boolean} [params.cacheMissResponseValid]
+ * @param {boolean | null} [params.cacheMissResponseValid]
  * @param {boolean} [params.enforceEgressQuota=false] - Whether to decrement
  *   egress quotas. Default is `false`
  * @param {boolean} [params.isBotTraffic=false] - Whether the egress traffic
@@ -143,4 +145,75 @@ export async function logRetrievalResult(env, params) {
     // TODO: Handle specific SQL error codes if needed
     throw error
   }
+}
+
+/**
+ * Records a failed retrieval: logs the resolved HTTP status with no egress and
+ * no data set, scheduled on the execution context. Intended for a worker's
+ * request error handler.
+ *
+ * @param {{ DB: D1Database }} env - Worker environment (contains D1 binding).
+ * @param {ExecutionContext} ctx
+ * @param {unknown} error - The error thrown while handling the request.
+ * @param {object} context
+ * @param {string | null} context.requestCountryCode
+ * @param {string} context.timestamp
+ * @param {string | undefined} context.botName
+ */
+export function logRetrievalError(
+  env,
+  ctx,
+  error,
+  { requestCountryCode, timestamp, botName },
+) {
+  const { status } = getErrorHttpStatusMessage(error)
+
+  ctx.waitUntil(
+    logRetrievalResult(env, {
+      cacheMiss: null,
+      cacheMissResponseValid: null,
+      responseStatus: status,
+      egressBytes: null,
+      requestCountryCode,
+      timestamp,
+      dataSetId: null,
+      botName,
+    }),
+  )
+}
+
+/**
+ * Records a completed retrieval: writes the retrieval log and updates the data
+ * set egress stats and quotas. These are always performed together for a
+ * successful streamed response.
+ *
+ * @param {{ DB: D1Database }} env - Worker environment (contains D1 binding).
+ * @param {object} params - Combined parameters for {@link logRetrievalResult}
+ *   and {@link updateDataSetStats}.
+ * @param {string} params.dataSetId
+ * @param {number} params.egressBytes
+ * @param {number} [params.cacheMissEgressBytes]
+ * @param {boolean} params.cacheMiss
+ * @param {boolean | null} params.cacheMissResponseValid
+ * @param {number} params.responseStatus
+ * @param {string | null} params.requestCountryCode
+ * @param {string} params.timestamp
+ * @param {{
+ *   fetchTtfb: number
+ *   fetchTtlb: number
+ *   workerTtfb: number
+ * }} [params.performanceStats]
+ * @param {string | undefined} params.botName
+ * @param {boolean} [params.enforceEgressQuota]
+ */
+export async function recordRetrieval(env, params) {
+  await logRetrievalResult(env, params)
+  await updateDataSetStats(env, {
+    dataSetId: params.dataSetId,
+    egressBytes: params.egressBytes,
+    cacheMissEgressBytes: params.cacheMissEgressBytes,
+    cacheMiss: params.cacheMiss,
+    cacheMissResponseValid: params.cacheMissResponseValid,
+    enforceEgressQuota: params.enforceEgressQuota,
+  })
 }

--- a/retrieval/test/redirect.test.js
+++ b/retrieval/test/redirect.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { redirectLegacyDomain } from '../lib/redirect.js'
+
+describe('redirectLegacyDomain', () => {
+  it('redirects *.filcdn.io to *.filbeam.io with a 301', () => {
+    const res = redirectLegacyDomain(
+      new Request('https://0xabc.filcdn.io/baga123?format=car'),
+    )
+    expect(res?.status).toBe(301)
+    expect(res?.headers.get('Location')).toBe(
+      'https://0xabc.filbeam.io/baga123?format=car',
+    )
+  })
+
+  it('returns undefined for non-legacy domains', () => {
+    expect(
+      redirectLegacyDomain(new Request('https://0xabc.filbeam.io/baga123')),
+    ).toBeUndefined()
+  })
+})

--- a/retrieval/test/stats.test.js
+++ b/retrieval/test/stats.test.js
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { updateDataSetStats, logRetrievalResult } from '../lib/stats'
+import {
+  updateDataSetStats,
+  logRetrievalResult,
+  logRetrievalError,
+  recordRetrieval,
+} from '../lib/stats'
 import { withDataSet } from './test-helpers'
-import { env } from 'cloudflare:test'
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from 'cloudflare:test'
 
 describe('updateDataSetStats', () => {
   it('updates egress stats', async () => {
@@ -354,5 +363,91 @@ describe('logRetrievalResult', () => {
       .first()
 
     expect(result).toEqual({ egress_bytes: 999, cache_miss_egress_bytes: 999 })
+  })
+})
+
+describe('logRetrievalError', () => {
+  it('logs the error status with no egress and no data set', async () => {
+    const ctx = createExecutionContext()
+
+    logRetrievalError(
+      env,
+      ctx,
+      Object.assign(new Error('Not Found'), { status: 404 }),
+      {
+        requestCountryCode: 'US',
+        timestamp: new Date().toISOString(),
+        botName: undefined,
+      },
+    )
+    await waitOnExecutionContext(ctx)
+
+    const result = await env.DB.prepare(
+      `SELECT response_status, egress_bytes, cache_miss, data_set_id
+       FROM retrieval_logs
+       WHERE response_status = 404 AND request_country_code = 'US'`,
+    ).all()
+
+    expect(result.results).toEqual([
+      {
+        response_status: 404,
+        egress_bytes: null,
+        cache_miss: null,
+        data_set_id: null,
+      },
+    ])
+  })
+})
+
+describe('recordRetrieval', () => {
+  it('writes the retrieval log and updates the data set egress stats', async () => {
+    const DATA_SET_ID = 'record-retrieval'
+    await withDataSet(env, {
+      dataSetId: DATA_SET_ID,
+      cdnEgressQuota: 1000,
+      cacheMissEgressQuota: 1000,
+    })
+
+    await recordRetrieval(env, {
+      dataSetId: DATA_SET_ID,
+      cacheMiss: true,
+      cacheMissResponseValid: true,
+      egressBytes: 100,
+      cacheMissEgressBytes: 250,
+      responseStatus: 200,
+      requestCountryCode: 'US',
+      timestamp: new Date().toISOString(),
+      enforceEgressQuota: true,
+    })
+
+    const log = await env.DB.prepare(
+      `SELECT egress_bytes, cache_miss_egress_bytes, cache_miss
+       FROM retrieval_logs WHERE data_set_id = ?`,
+    )
+      .bind(DATA_SET_ID)
+      .first()
+    expect(log).toEqual({
+      egress_bytes: 100,
+      cache_miss_egress_bytes: 250,
+      cache_miss: 1,
+    })
+
+    const dataSet = await env.DB.prepare(
+      `SELECT total_egress_bytes_used FROM data_sets WHERE id = ?`,
+    )
+      .bind(DATA_SET_ID)
+      .first()
+    expect(dataSet.total_egress_bytes_used).toBe(100)
+
+    const quota = await env.DB.prepare(
+      `SELECT cdn_egress_quota, cache_miss_egress_quota
+       FROM data_set_egress_quotas WHERE data_set_id = ?`,
+    )
+      .bind(DATA_SET_ID)
+      .first()
+    expect(quota).toEqual({
+      cdn_egress_quota: 1000 - 100,
+      cache_miss_egress_quota: 1000 - 250,
+    })
   })
 })


### PR DESCRIPTION
Stacked on `serve-ipfs-retrievals`. Tier 2 of the retriever de-duplication.

Extracts three shared helpers into `@filbeam/retrieval` and uses them in both `ipfs-retriever` and `piece-retriever`.

## Helpers

`redirectLegacyDomain(request)` returns the `*.filcdn.io` to `*.filbeam.io` 301 redirect, or undefined.

`logRetrievalError(env, ctx, error, ctxFields)` is the request error handler tail, it logs the failed retrieval (resolved status, no egress, no data set) on the execution context.

`recordRetrieval(env, params)` is the success path tail, it writes the retrieval log and updates the data set egress stats/quota, which were always called together.

## Left per-worker

The stream measurement itself is not unified. The two workers genuinely differ here, ipfs-retriever tees the stream and counts bytes, piece-retriever pipes through a TransformStream and also runs CommP validation, interval stream-stats logging, and cache invalidation. Sharing only the log/stats tail (`recordRetrieval`) captures the common part without coupling those mechanics.

## Notes

Not sure this is worth landing, opening for evaluation as agreed. If we keep it, it sits under the main `serve-ipfs-retrievals` PR.