### PR TITLE
DRY: share the retrieval authorization cascade (Tier 3)

### DIFF
--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -48,21 +48,24 @@ const SELECT_CANDIDATES_BY_CID = `
 function validateQueryResultsAndGetCandidates(params) {
   const { results, payerAddress, lookupKey } = params
 
-  const withApprovedProvider = filterAuthorizedRetrievalCandidates(results, {
-    payerAddress,
-    messages: {
-      notIndexed: `${lookupKey} does not exist or may not have been indexed yet.`,
-      noServiceProvider: `${lookupKey} exists but has no associated service provider.`,
-      noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey}.`,
-      cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withCDN=false.`,
-      sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${lookupKey}.`,
-      noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and ${lookupKey}.`,
+  const authorizedRetrievalCandidates = filterAuthorizedRetrievalCandidates(
+    results,
+    {
+      payerAddress,
+      messages: {
+        notIndexed: `${lookupKey} does not exist or may not have been indexed yet.`,
+        noServiceProvider: `${lookupKey} exists but has no associated service provider.`,
+        noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey}.`,
+        cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withCDN=false.`,
+        sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${lookupKey}.`,
+        noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and ${lookupKey}.`,
+      },
     },
-  })
+  )
 
   // IPFS indexing is specific to IPFS retrievals, so it is checked here rather
   // than in the shared cascade.
-  const withIpfsIndexing = withApprovedProvider.filter(
+  const withIpfsIndexing = authorizedRetrievalCandidates.filter(
     (row) => row.with_ipfs_indexing === 1,
   )
   httpAssert(

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -1,5 +1,5 @@
 import { bigIntToBase32 } from './bigint-util.js'
-import { httpAssert } from '@filbeam/retrieval'
+import { httpAssert, filterAuthorizedRetrievalRows } from '@filbeam/retrieval'
 
 const SELECT_CANDIDATES_BY_CID = `
    SELECT
@@ -44,64 +44,18 @@ const SELECT_CANDIDATES_BY_CID = `
 function validateQueryResultsAndGetCandidates(params) {
   const { results, payerAddress, lookupKey } = params
 
-  httpAssert(
-    results && results.length > 0,
-    404,
-    `${lookupKey} does not exist or may not have been indexed yet.`,
-  )
-
-  const withServiceProvider = results.filter(
-    (row) => row && row.service_provider_id != null,
-  )
-  httpAssert(
-    withServiceProvider.length > 0,
-    404,
-    `${lookupKey} exists but has no associated service provider.`,
-  )
-
-  const withPaymentRail = withServiceProvider.filter(
-    (row) =>
-      row.payer_address && row.payer_address.toLowerCase() === payerAddress,
-  )
-  httpAssert(
-    withPaymentRail.length > 0,
-    402,
-    `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey}.`,
-  )
-
-  const withCDN = withPaymentRail.filter(
-    (row) => row.with_cdn && row.with_cdn === 1,
-  )
-  httpAssert(
-    withCDN.length > 0,
-    402,
-    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withCDN=false.`,
-  )
-
-  const withIpfsIndexing = withCDN.filter((row) => row.with_ipfs_indexing === 1)
-  httpAssert(
-    withIpfsIndexing.length > 0,
-    402,
-    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withIpfsIndexing=false.`,
-  )
-
-  const withPayerNotSanctioned = withIpfsIndexing.filter(
-    (row) => !row.is_sanctioned,
-  )
-  httpAssert(
-    withPayerNotSanctioned.length > 0,
-    403,
-    `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${lookupKey}.`,
-  )
-
-  const withApprovedProvider = withPayerNotSanctioned.filter(
-    (row) => row.service_url,
-  )
-  httpAssert(
-    withApprovedProvider.length > 0,
-    404,
-    `No approved service provider found for payer '${payerAddress}' and ${lookupKey}.`,
-  )
+  const withApprovedProvider = filterAuthorizedRetrievalRows(results, {
+    payerAddress,
+    ipfsIndexingDisabledMessage: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withIpfsIndexing=false.`,
+    messages: {
+      notIndexed: `${lookupKey} does not exist or may not have been indexed yet.`,
+      noServiceProvider: `${lookupKey} exists but has no associated service provider.`,
+      noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey}.`,
+      cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withCDN=false.`,
+      sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${lookupKey}.`,
+      noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and ${lookupKey}.`,
+    },
+  })
 
   const withIpfsRootCid = withApprovedProvider.filter(
     (row) => row.ipfs_root_cid,

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -50,7 +50,7 @@ function validateQueryResultsAndGetCandidates(params) {
 
   const authorizedRetrievalCandidates = filterAuthorizedRetrievalCandidates(
     results,
-    { payerAddress, subject: lookupKey },
+    { payerAddress },
   )
 
   // IPFS indexing is specific to IPFS retrievals, so it is checked here rather

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -53,8 +53,6 @@ function validateQueryResultsAndGetCandidates(params) {
     { payerAddress },
   )
 
-  // IPFS indexing is specific to IPFS retrievals, so it is checked here rather
-  // than in the shared cascade.
   const withIpfsIndexing = authorizedRetrievalCandidates.filter(
     (row) => row.with_ipfs_indexing === 1,
   )

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -50,17 +50,7 @@ function validateQueryResultsAndGetCandidates(params) {
 
   const authorizedRetrievalCandidates = filterAuthorizedRetrievalCandidates(
     results,
-    {
-      payerAddress,
-      messages: {
-        notIndexed: `${lookupKey} does not exist or may not have been indexed yet.`,
-        noServiceProvider: `${lookupKey} exists but has no associated service provider.`,
-        noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey}.`,
-        cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withCDN=false.`,
-        sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${lookupKey}.`,
-        noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and ${lookupKey}.`,
-      },
-    },
+    { payerAddress, subject: lookupKey },
   )
 
   // IPFS indexing is specific to IPFS retrievals, so it is checked here rather

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -1,5 +1,8 @@
 import { bigIntToBase32 } from './bigint-util.js'
-import { httpAssert, filterAuthorizedRetrievalRows } from '@filbeam/retrieval'
+import {
+  httpAssert,
+  filterAuthorizedRetrievalCandidates,
+} from '@filbeam/retrieval'
 
 const SELECT_CANDIDATES_BY_CID = `
    SELECT
@@ -45,7 +48,7 @@ const SELECT_CANDIDATES_BY_CID = `
 function validateQueryResultsAndGetCandidates(params) {
   const { results, payerAddress, lookupKey } = params
 
-  const withApprovedProvider = filterAuthorizedRetrievalRows(results, {
+  const withApprovedProvider = filterAuthorizedRetrievalCandidates(results, {
     payerAddress,
     messages: {
       notIndexed: `${lookupKey} does not exist or may not have been indexed yet.`,

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -11,6 +11,7 @@ const SELECT_CANDIDATES_BY_CID = `
      data_sets.with_cdn,
      data_sets.with_ipfs_indexing,
      service_providers.service_url,
+     service_providers.is_deleted as service_provider_is_deleted,
      wallet_details.is_sanctioned
    FROM pieces
    LEFT OUTER JOIN data_sets

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -47,7 +47,6 @@ function validateQueryResultsAndGetCandidates(params) {
 
   const withApprovedProvider = filterAuthorizedRetrievalRows(results, {
     payerAddress,
-    ipfsIndexingDisabledMessage: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withIpfsIndexing=false.`,
     messages: {
       notIndexed: `${lookupKey} does not exist or may not have been indexed yet.`,
       noServiceProvider: `${lookupKey} exists but has no associated service provider.`,
@@ -58,9 +57,18 @@ function validateQueryResultsAndGetCandidates(params) {
     },
   })
 
-  const withIpfsRootCid = withApprovedProvider.filter(
-    (row) => row.ipfs_root_cid,
+  // IPFS indexing is specific to IPFS retrievals, so it is checked here rather
+  // than in the shared cascade.
+  const withIpfsIndexing = withApprovedProvider.filter(
+    (row) => row.with_ipfs_indexing === 1,
   )
+  httpAssert(
+    withIpfsIndexing.length > 0,
+    402,
+    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${lookupKey} has withIpfsIndexing=false.`,
+  )
+
+  const withIpfsRootCid = withIpfsIndexing.filter((row) => row.ipfs_root_cid)
   httpAssert(
     withIpfsRootCid.length > 0,
     404,

--- a/ipfs-retriever/test/retriever.test.js
+++ b/ipfs-retriever/test/retriever.test.js
@@ -845,7 +845,7 @@ describe('retriever.fetch', () => {
     // Expect an error because no URL was found
     expect(res.status).toBe(404)
     expect(await res.text()).toBe(
-      `No approved service provider found for payer '0x2a06d234246ed18b6c91de8349ff34c22c7268e8' and data set ID '${dataSetId}' and piece ID '${pieceId}'.`,
+      `No approved service provider found for payer '0x2a06d234246ed18b6c91de8349ff34c22c7268e8' and the requested content.`,
     )
   })
 

--- a/ipfs-retriever/test/store.test.js
+++ b/ipfs-retriever/test/store.test.js
@@ -491,6 +491,37 @@ describe('getRetrievalCandidatesByDataSetAndPiece', () => {
       [serviceProviderId1, serviceProviderId2].sort(),
     )
   })
+
+  it('excludes soft-deleted service providers', async () => {
+    const payerAddress = '0xabc123def456abc123def456abc123def456abc9'
+    const ipfsRootCid = 'bafkbyids9deleted'
+    const serviceProviderId = 'sp-byids-9-deleted'
+
+    await withApprovedProvider(env, {
+      id: serviceProviderId,
+      serviceUrl: 'https://sp9.xyz',
+    })
+    await env.DB.prepare(
+      'UPDATE service_providers SET is_deleted = TRUE WHERE id = ?',
+    )
+      .bind(serviceProviderId)
+      .run()
+    await withDataSetPiece(env, {
+      payerAddress,
+      serviceProviderId,
+      dataSetId: 'ds-9',
+      pieceId: 'piece-9',
+      withCDN: true,
+      withIpfsIndexing: true,
+      ipfsRootCid,
+    })
+
+    await assert.rejects(
+      async () =>
+        await getRetrievalCandidatesByDataSetAndPiece(env, 'ds-9', 'piece-9'),
+      /has no associated service provider/,
+    )
+  })
 })
 
 describe('getSlugForWalletAndCid', () => {

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -72,17 +72,7 @@ export async function getRetrievalCandidatesAndValidatePayer(
   )
   const authorizedRetrievalCandidates = filterAuthorizedRetrievalCandidates(
     results,
-    {
-      payerAddress,
-      messages: {
-        notIndexed: `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,
-        noServiceProvider: `Piece_cid '${pieceCid}' exists but has no associated service provider.`,
-        noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
-        cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}' has withCDN=false.`,
-        sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve piece_cid '${pieceCid}'.`,
-        noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
-      },
-    },
+    { payerAddress, subject: `piece_cid '${pieceCid}'` },
   )
 
   // Check CDN quota first

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -72,7 +72,7 @@ export async function getRetrievalCandidatesAndValidatePayer(
   )
   const authorizedRetrievalCandidates = filterAuthorizedRetrievalCandidates(
     results,
-    { payerAddress, subject: `piece_cid '${pieceCid}'` },
+    { payerAddress },
   )
 
   // Check CDN quota first

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -1,4 +1,4 @@
-import { httpAssert } from '@filbeam/retrieval'
+import { httpAssert, filterAuthorizedRetrievalRows } from '@filbeam/retrieval'
 
 /**
  * Retrieves the provider and data set id for a given root CID.
@@ -67,58 +67,18 @@ export async function getRetrievalCandidatesAndValidatePayer(
       (await env.DB.prepare(query).bind(pieceCid).all()).results
     )
   )
-  httpAssert(
-    results && results.length > 0,
-    404,
-    `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,
-  )
-
-  const withServiceProvider = results.filter(
-    (row) =>
-      row &&
-      row.service_provider_id != null &&
-      !row.service_provider_is_deleted,
-  )
-  httpAssert(
-    withServiceProvider.length > 0,
-    404,
-    `Piece_cid '${pieceCid}' exists but has no associated service provider.`,
-  )
-
-  const withPaymentRail = withServiceProvider.filter(
-    (row) =>
-      row.payer_address && row.payer_address.toLowerCase() === payerAddress,
-  )
-  httpAssert(
-    withPaymentRail.length > 0,
-    402,
-    `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
-  )
-
-  const withCDN = withPaymentRail.filter(
-    (row) => row.with_cdn && row.with_cdn === 1,
-  )
-  httpAssert(
-    withCDN.length > 0,
-    402,
-    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}' has withCDN=false.`,
-  )
-
-  const withPayerNotSanctioned = withCDN.filter((row) => !row.is_sanctioned)
-  httpAssert(
-    withPayerNotSanctioned.length > 0,
-    403,
-    `Wallet '${payerAddress}' is sanctioned and cannot retrieve piece_cid '${pieceCid}'.`,
-  )
-
-  const withApprovedProvider = withPayerNotSanctioned.filter(
-    (row) => row.service_url,
-  )
-  httpAssert(
-    withApprovedProvider.length > 0,
-    404,
-    `No approved service provider found for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
-  )
+  const withApprovedProvider = filterAuthorizedRetrievalRows(results, {
+    payerAddress,
+    requireServiceProviderNotDeleted: true,
+    messages: {
+      notIndexed: `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,
+      noServiceProvider: `Piece_cid '${pieceCid}' exists but has no associated service provider.`,
+      noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
+      cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}' has withCDN=false.`,
+      sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve piece_cid '${pieceCid}'.`,
+      noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
+    },
+  })
 
   // Check CDN quota first
   const withSufficientCDNQuota = enforceEgressQuota

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -1,4 +1,7 @@
-import { httpAssert, filterAuthorizedRetrievalRows } from '@filbeam/retrieval'
+import {
+  httpAssert,
+  filterAuthorizedRetrievalCandidates,
+} from '@filbeam/retrieval'
 
 /**
  * Retrieves the provider and data set id for a given root CID.
@@ -67,7 +70,7 @@ export async function getRetrievalCandidatesAndValidatePayer(
       (await env.DB.prepare(query).bind(pieceCid).all()).results
     )
   )
-  const withApprovedProvider = filterAuthorizedRetrievalRows(results, {
+  const withApprovedProvider = filterAuthorizedRetrievalCandidates(results, {
     payerAddress,
     messages: {
       notIndexed: `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -70,29 +70,32 @@ export async function getRetrievalCandidatesAndValidatePayer(
       (await env.DB.prepare(query).bind(pieceCid).all()).results
     )
   )
-  const withApprovedProvider = filterAuthorizedRetrievalCandidates(results, {
-    payerAddress,
-    messages: {
-      notIndexed: `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,
-      noServiceProvider: `Piece_cid '${pieceCid}' exists but has no associated service provider.`,
-      noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
-      cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}' has withCDN=false.`,
-      sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve piece_cid '${pieceCid}'.`,
-      noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
+  const authorizedRetrievalCandidates = filterAuthorizedRetrievalCandidates(
+    results,
+    {
+      payerAddress,
+      messages: {
+        notIndexed: `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,
+        noServiceProvider: `Piece_cid '${pieceCid}' exists but has no associated service provider.`,
+        noPaymentRail: `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
+        cdnDisabled: `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and piece_cid '${pieceCid}' has withCDN=false.`,
+        sanctioned: `Wallet '${payerAddress}' is sanctioned and cannot retrieve piece_cid '${pieceCid}'.`,
+        noApprovedProvider: `No approved service provider found for payer '${payerAddress}' and piece_cid '${pieceCid}'.`,
+      },
     },
-  })
+  )
 
   // Check CDN quota first
   const withSufficientCDNQuota = enforceEgressQuota
-    ? withApprovedProvider.filter((row) => {
+    ? authorizedRetrievalCandidates.filter((row) => {
         return BigInt(row.cdn_egress_quota ?? '0') > 0n
       })
-    : withApprovedProvider
+    : authorizedRetrievalCandidates
 
   httpAssert(
     withSufficientCDNQuota.length > 0,
     402,
-    `CDN egress quota exhausted for payer '${payerAddress}' and data set '${withApprovedProvider[0]?.data_set_id}'. Please top up your CDN egress quota.`,
+    `CDN egress quota exhausted for payer '${payerAddress}' and data set '${authorizedRetrievalCandidates[0]?.data_set_id}'. Please top up your CDN egress quota.`,
   )
 
   // Check cache-miss quota

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -69,7 +69,6 @@ export async function getRetrievalCandidatesAndValidatePayer(
   )
   const withApprovedProvider = filterAuthorizedRetrievalRows(results, {
     payerAddress,
-    requireServiceProviderNotDeleted: true,
     messages: {
       notIndexed: `Piece_cid '${pieceCid}' does not exist or may not have been indexed yet.`,
       noServiceProvider: `Piece_cid '${pieceCid}' exists but has no associated service provider.`,

--- a/piece-retriever/test/retriever.test.js
+++ b/piece-retriever/test/retriever.test.js
@@ -582,7 +582,7 @@ describe('piece-retriever.fetch', () => {
     // Expect an error because no URL was found
     expect(res.status).toBe(404)
     expect(await res.text()).toBe(
-      `No approved service provider found for payer '0x2a06d234246ed18b6c91de8349ff34c22c7268e8' and piece_cid 'bagaTest'.`,
+      `No approved service provider found for payer '0x2a06d234246ed18b6c91de8349ff34c22c7268e8' and the requested content.`,
     )
   })
 

--- a/retrieval/index.js
+++ b/retrieval/index.js
@@ -1,3 +1,4 @@
+export * from './lib/access.js'
 export * from './lib/address.js'
 export * from './lib/bad-bits-util.js'
 export * from './lib/bot-auth.js'

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -20,8 +20,6 @@ import { httpAssert } from './http-assert.js'
  * @param {string} options.messages.cdnDisabled
  * @param {string} options.messages.sanctioned
  * @param {string} options.messages.noApprovedProvider
- * @param {boolean} [options.requireServiceProviderNotDeleted] - Also exclude
- *   rows whose service provider is soft-deleted.
  * @param {string} [options.ipfsIndexingDisabledMessage] - When provided, also
  *   require IPFS indexing to be enabled on the deal, throwing this message
  *   otherwise.
@@ -29,12 +27,7 @@ import { httpAssert } from './http-assert.js'
  */
 export function filterAuthorizedRetrievalRows(
   rows,
-  {
-    payerAddress,
-    messages,
-    requireServiceProviderNotDeleted = false,
-    ipfsIndexingDisabledMessage,
-  },
+  { payerAddress, messages, ipfsIndexingDisabledMessage },
 ) {
   httpAssert(rows && rows.length > 0, 404, messages.notIndexed)
 
@@ -42,7 +35,7 @@ export function filterAuthorizedRetrievalRows(
     (row) =>
       row &&
       row.service_provider_id != null &&
-      (!requireServiceProviderNotDeleted || !row.service_provider_is_deleted),
+      !row.service_provider_is_deleted,
   )
   httpAssert(withServiceProvider.length > 0, 404, messages.noServiceProvider)
 

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -13,18 +13,13 @@ import { httpAssert } from './http-assert.js'
  * @param {any[]} rows
  * @param {object} options
  * @param {string} options.payerAddress - Lower-cased payer address to match.
- * @param {string} options.subject - The content being retrieved, used in error
- *   messages (e.g. "IPFS Root CID 'bafk...'" or "piece_cid 'baga...'").
  * @returns {any[]} The rows passing every check.
  */
-export function filterAuthorizedRetrievalCandidates(
-  rows,
-  { payerAddress, subject },
-) {
+export function filterAuthorizedRetrievalCandidates(rows, { payerAddress }) {
   httpAssert(
     rows && rows.length > 0,
     404,
-    `${subject} does not exist or may not have been indexed yet.`,
+    'The requested content does not exist or may not have been indexed yet.',
   )
 
   const withServiceProvider = rows.filter(
@@ -36,7 +31,7 @@ export function filterAuthorizedRetrievalCandidates(
   httpAssert(
     withServiceProvider.length > 0,
     404,
-    `${subject} exists but has no associated service provider.`,
+    'The requested content exists but has no associated service provider.',
   )
 
   const withPaymentRail = withServiceProvider.filter(
@@ -46,7 +41,7 @@ export function filterAuthorizedRetrievalCandidates(
   httpAssert(
     withPaymentRail.length > 0,
     402,
-    `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject}.`,
+    `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and the requested content.`,
   )
 
   const withCDN = withPaymentRail.filter(
@@ -55,14 +50,14 @@ export function filterAuthorizedRetrievalCandidates(
   httpAssert(
     withCDN.length > 0,
     402,
-    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject} has withCDN=false.`,
+    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and the requested content has withCDN=false.`,
   )
 
   const withPayerNotSanctioned = withCDN.filter((row) => !row.is_sanctioned)
   httpAssert(
     withPayerNotSanctioned.length > 0,
     403,
-    `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${subject}.`,
+    `Wallet '${payerAddress}' is sanctioned and cannot retrieve the requested content.`,
   )
 
   const authorizedRetrievalCandidates = withPayerNotSanctioned.filter(
@@ -71,7 +66,7 @@ export function filterAuthorizedRetrievalCandidates(
   httpAssert(
     authorizedRetrievalCandidates.length > 0,
     404,
-    `No approved service provider found for payer '${payerAddress}' and ${subject}.`,
+    `No approved service provider found for payer '${payerAddress}' and the requested content.`,
   )
 
   return authorizedRetrievalCandidates

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -22,7 +22,7 @@ import { httpAssert } from './http-assert.js'
  * @param {string} options.messages.noApprovedProvider
  * @returns {any[]} The rows passing every check.
  */
-export function filterAuthorizedRetrievalRows(
+export function filterAuthorizedRetrievalCandidates(
   rows,
   { payerAddress, messages },
 ) {

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -1,0 +1,77 @@
+import { httpAssert } from './http-assert.js'
+
+/**
+ * Runs the shared retrieval authorization cascade over candidate rows joined
+ * from pieces, data_sets, service_providers and wallet_details. Each check
+ * filters the rows and throws an httpAssert error with the caller-provided
+ * message when no row survives. Returns the rows that pass every check.
+ *
+ * The checks run in order: indexed, has a (non-deleted) service provider, has a
+ * payment rail for the payer, has CDN enabled, (optionally) has IPFS indexing
+ * enabled, payer is not sanctioned, and the service provider is approved.
+ *
+ * @param {any[]} rows
+ * @param {object} options
+ * @param {string} options.payerAddress - Lower-cased payer address to match.
+ * @param {object} options.messages - Error messages per failed check.
+ * @param {string} options.messages.notIndexed
+ * @param {string} options.messages.noServiceProvider
+ * @param {string} options.messages.noPaymentRail
+ * @param {string} options.messages.cdnDisabled
+ * @param {string} options.messages.sanctioned
+ * @param {string} options.messages.noApprovedProvider
+ * @param {boolean} [options.requireServiceProviderNotDeleted] - Also exclude
+ *   rows whose service provider is soft-deleted.
+ * @param {string} [options.ipfsIndexingDisabledMessage] - When provided, also
+ *   require IPFS indexing to be enabled on the deal, throwing this message
+ *   otherwise.
+ * @returns {any[]} The rows passing every check.
+ */
+export function filterAuthorizedRetrievalRows(
+  rows,
+  {
+    payerAddress,
+    messages,
+    requireServiceProviderNotDeleted = false,
+    ipfsIndexingDisabledMessage,
+  },
+) {
+  httpAssert(rows && rows.length > 0, 404, messages.notIndexed)
+
+  const withServiceProvider = rows.filter(
+    (row) =>
+      row &&
+      row.service_provider_id != null &&
+      (!requireServiceProviderNotDeleted || !row.service_provider_is_deleted),
+  )
+  httpAssert(withServiceProvider.length > 0, 404, messages.noServiceProvider)
+
+  const withPaymentRail = withServiceProvider.filter(
+    (row) =>
+      row.payer_address && row.payer_address.toLowerCase() === payerAddress,
+  )
+  httpAssert(withPaymentRail.length > 0, 402, messages.noPaymentRail)
+
+  const withCDN = withPaymentRail.filter(
+    (row) => row.with_cdn && row.with_cdn === 1,
+  )
+  httpAssert(withCDN.length > 0, 402, messages.cdnDisabled)
+
+  let rowsAfterCdn = withCDN
+  if (ipfsIndexingDisabledMessage) {
+    rowsAfterCdn = withCDN.filter((row) => row.with_ipfs_indexing === 1)
+    httpAssert(rowsAfterCdn.length > 0, 402, ipfsIndexingDisabledMessage)
+  }
+
+  const withPayerNotSanctioned = rowsAfterCdn.filter(
+    (row) => !row.is_sanctioned,
+  )
+  httpAssert(withPayerNotSanctioned.length > 0, 403, messages.sanctioned)
+
+  const withApprovedProvider = withPayerNotSanctioned.filter(
+    (row) => row.service_url,
+  )
+  httpAssert(withApprovedProvider.length > 0, 404, messages.noApprovedProvider)
+
+  return withApprovedProvider
+}

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -1,19 +1,33 @@
 import { httpAssert } from './http-assert.js'
 
 /**
+ * The columns the authorization cascade reads from a candidate row. Callers may
+ * pass rows with additional columns, which are preserved in the return value.
+ *
+ * @typedef {object} RetrievalCandidateRow
+ * @property {string | null} [service_provider_id]
+ * @property {boolean | null} [service_provider_is_deleted]
+ * @property {string | null} [payer_address]
+ * @property {number | null} [with_cdn]
+ * @property {number | boolean | null} [is_sanctioned]
+ * @property {string | null} [service_url]
+ */
+
+/**
  * Runs the shared retrieval authorization cascade over candidate rows joined
  * from pieces, data_sets, service_providers and wallet_details. Each check
- * filters the rows and throws an httpAssert error with the caller-provided
- * message when no row survives. Returns the rows that pass every check.
+ * filters the rows and throws an httpAssert error when no row survives. Returns
+ * the rows that pass every check.
  *
  * The checks run in order: indexed, has a (non-deleted) service provider, has a
  * payment rail for the payer, has CDN enabled, payer is not sanctioned, and the
  * service provider is approved.
  *
- * @param {any[]} rows
+ * @template {RetrievalCandidateRow} Row
+ * @param {Row[]} rows
  * @param {object} options
  * @param {string} options.payerAddress - Lower-cased payer address to match.
- * @returns {any[]} The rows passing every check.
+ * @returns {Row[]} The rows passing every check.
  */
 export function filterAuthorizedRetrievalCandidates(rows, { payerAddress }) {
   httpAssert(

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -7,8 +7,8 @@ import { httpAssert } from './http-assert.js'
  * message when no row survives. Returns the rows that pass every check.
  *
  * The checks run in order: indexed, has a (non-deleted) service provider, has a
- * payment rail for the payer, has CDN enabled, (optionally) has IPFS indexing
- * enabled, payer is not sanctioned, and the service provider is approved.
+ * payment rail for the payer, has CDN enabled, payer is not sanctioned, and the
+ * service provider is approved.
  *
  * @param {any[]} rows
  * @param {object} options
@@ -20,14 +20,11 @@ import { httpAssert } from './http-assert.js'
  * @param {string} options.messages.cdnDisabled
  * @param {string} options.messages.sanctioned
  * @param {string} options.messages.noApprovedProvider
- * @param {string} [options.ipfsIndexingDisabledMessage] - When provided, also
- *   require IPFS indexing to be enabled on the deal, throwing this message
- *   otherwise.
  * @returns {any[]} The rows passing every check.
  */
 export function filterAuthorizedRetrievalRows(
   rows,
-  { payerAddress, messages, ipfsIndexingDisabledMessage },
+  { payerAddress, messages },
 ) {
   httpAssert(rows && rows.length > 0, 404, messages.notIndexed)
 
@@ -50,15 +47,7 @@ export function filterAuthorizedRetrievalRows(
   )
   httpAssert(withCDN.length > 0, 402, messages.cdnDisabled)
 
-  let rowsAfterCdn = withCDN
-  if (ipfsIndexingDisabledMessage) {
-    rowsAfterCdn = withCDN.filter((row) => row.with_ipfs_indexing === 1)
-    httpAssert(rowsAfterCdn.length > 0, 402, ipfsIndexingDisabledMessage)
-  }
-
-  const withPayerNotSanctioned = rowsAfterCdn.filter(
-    (row) => !row.is_sanctioned,
-  )
+  const withPayerNotSanctioned = withCDN.filter((row) => !row.is_sanctioned)
   httpAssert(withPayerNotSanctioned.length > 0, 403, messages.sanctioned)
 
   const withApprovedProvider = withPayerNotSanctioned.filter(

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -13,20 +13,19 @@ import { httpAssert } from './http-assert.js'
  * @param {any[]} rows
  * @param {object} options
  * @param {string} options.payerAddress - Lower-cased payer address to match.
- * @param {object} options.messages - Error messages per failed check.
- * @param {string} options.messages.notIndexed
- * @param {string} options.messages.noServiceProvider
- * @param {string} options.messages.noPaymentRail
- * @param {string} options.messages.cdnDisabled
- * @param {string} options.messages.sanctioned
- * @param {string} options.messages.noApprovedProvider
+ * @param {string} options.subject - The content being retrieved, used in error
+ *   messages (e.g. "IPFS Root CID 'bafk...'" or "piece_cid 'baga...'").
  * @returns {any[]} The rows passing every check.
  */
 export function filterAuthorizedRetrievalCandidates(
   rows,
-  { payerAddress, messages },
+  { payerAddress, subject },
 ) {
-  httpAssert(rows && rows.length > 0, 404, messages.notIndexed)
+  httpAssert(
+    rows && rows.length > 0,
+    404,
+    `${subject} does not exist or may not have been indexed yet.`,
+  )
 
   const withServiceProvider = rows.filter(
     (row) =>
@@ -34,21 +33,37 @@ export function filterAuthorizedRetrievalCandidates(
       row.service_provider_id != null &&
       !row.service_provider_is_deleted,
   )
-  httpAssert(withServiceProvider.length > 0, 404, messages.noServiceProvider)
+  httpAssert(
+    withServiceProvider.length > 0,
+    404,
+    `${subject} exists but has no associated service provider.`,
+  )
 
   const withPaymentRail = withServiceProvider.filter(
     (row) =>
       row.payer_address && row.payer_address.toLowerCase() === payerAddress,
   )
-  httpAssert(withPaymentRail.length > 0, 402, messages.noPaymentRail)
+  httpAssert(
+    withPaymentRail.length > 0,
+    402,
+    `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject}.`,
+  )
 
   const withCDN = withPaymentRail.filter(
     (row) => row.with_cdn && row.with_cdn === 1,
   )
-  httpAssert(withCDN.length > 0, 402, messages.cdnDisabled)
+  httpAssert(
+    withCDN.length > 0,
+    402,
+    `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject} has withCDN=false.`,
+  )
 
   const withPayerNotSanctioned = withCDN.filter((row) => !row.is_sanctioned)
-  httpAssert(withPayerNotSanctioned.length > 0, 403, messages.sanctioned)
+  httpAssert(
+    withPayerNotSanctioned.length > 0,
+    403,
+    `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${subject}.`,
+  )
 
   const authorizedRetrievalCandidates = withPayerNotSanctioned.filter(
     (row) => row.service_url,
@@ -56,7 +71,7 @@ export function filterAuthorizedRetrievalCandidates(
   httpAssert(
     authorizedRetrievalCandidates.length > 0,
     404,
-    messages.noApprovedProvider,
+    `No approved service provider found for payer '${payerAddress}' and ${subject}.`,
   )
 
   return authorizedRetrievalCandidates

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -50,10 +50,14 @@ export function filterAuthorizedRetrievalCandidates(
   const withPayerNotSanctioned = withCDN.filter((row) => !row.is_sanctioned)
   httpAssert(withPayerNotSanctioned.length > 0, 403, messages.sanctioned)
 
-  const withApprovedProvider = withPayerNotSanctioned.filter(
+  const authorizedRetrievalCandidates = withPayerNotSanctioned.filter(
     (row) => row.service_url,
   )
-  httpAssert(withApprovedProvider.length > 0, 404, messages.noApprovedProvider)
+  httpAssert(
+    authorizedRetrievalCandidates.length > 0,
+    404,
+    messages.noApprovedProvider,
+  )
 
-  return withApprovedProvider
+  return authorizedRetrievalCandidates
 }

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -1,14 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { filterAuthorizedRetrievalCandidates } from '../lib/access.js'
 
-const MESSAGES = {
-  notIndexed: 'not indexed',
-  noServiceProvider: 'no service provider',
-  noPaymentRail: 'no payment rail',
-  cdnDisabled: 'cdn disabled',
-  sanctioned: 'sanctioned',
-  noApprovedProvider: 'no approved provider',
-}
+const payerAddress = '0xabcdef'
+const subject = "IPFS Root CID 'bafktest'"
 
 /** A row that passes every check. payer_address is upper-cased on purpose. */
 function authorizedRow(overrides = {}) {
@@ -37,27 +31,18 @@ function expectHttpError(fn, status, message) {
 }
 
 describe('filterAuthorizedRetrievalCandidates', () => {
-  const payerAddress = '0xabcdef'
-
   it('returns the rows passing every check, matching the payer case-insensitively', () => {
     const rows = [authorizedRow()]
     expect(
-      filterAuthorizedRetrievalCandidates(rows, {
-        payerAddress,
-        messages: MESSAGES,
-      }),
+      filterAuthorizedRetrievalCandidates(rows, { payerAddress, subject }),
     ).toEqual(rows)
   })
 
   it('throws 404 when there are no rows', () => {
     expectHttpError(
-      () =>
-        filterAuthorizedRetrievalCandidates([], {
-          payerAddress,
-          messages: MESSAGES,
-        }),
+      () => filterAuthorizedRetrievalCandidates([], { payerAddress, subject }),
       404,
-      MESSAGES.notIndexed,
+      `${subject} does not exist or may not have been indexed yet.`,
     )
   })
 
@@ -66,10 +51,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_provider_id: null })],
-          { payerAddress, messages: MESSAGES },
+          { payerAddress, subject },
         ),
       404,
-      MESSAGES.noServiceProvider,
+      `${subject} exists but has no associated service provider.`,
     )
   })
 
@@ -78,10 +63,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_provider_is_deleted: 1 })],
-          { payerAddress, messages: MESSAGES },
+          { payerAddress, subject },
         ),
       404,
-      MESSAGES.noServiceProvider,
+      `${subject} exists but has no associated service provider.`,
     )
   })
 
@@ -90,10 +75,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ payer_address: '0xother' })],
-          { payerAddress, messages: MESSAGES },
+          { payerAddress, subject },
         ),
       402,
-      MESSAGES.noPaymentRail,
+      `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject}.`,
     )
   })
 
@@ -102,10 +87,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates([authorizedRow({ with_cdn: 0 })], {
           payerAddress,
-          messages: MESSAGES,
+          subject,
         }),
       402,
-      MESSAGES.cdnDisabled,
+      `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject} has withCDN=false.`,
     )
   })
 
@@ -114,13 +99,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ is_sanctioned: 1 })],
-          {
-            payerAddress,
-            messages: MESSAGES,
-          },
+          { payerAddress, subject },
         ),
       403,
-      MESSAGES.sanctioned,
+      `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${subject}.`,
     )
   })
 
@@ -129,13 +111,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_url: null })],
-          {
-            payerAddress,
-            messages: MESSAGES,
-          },
+          { payerAddress, subject },
         ),
       404,
-      MESSAGES.noApprovedProvider,
+      `No approved service provider found for payer '${payerAddress}' and ${subject}.`,
     )
   })
 })

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import { filterAuthorizedRetrievalCandidates } from '../lib/access.js'
 
 const payerAddress = '0xabcdef'
-const subject = "IPFS Root CID 'bafktest'"
 
 /** A row that passes every check. payer_address is upper-cased on purpose. */
 function authorizedRow(overrides = {}) {
@@ -33,16 +32,16 @@ function expectHttpError(fn, status, message) {
 describe('filterAuthorizedRetrievalCandidates', () => {
   it('returns the rows passing every check, matching the payer case-insensitively', () => {
     const rows = [authorizedRow()]
-    expect(
-      filterAuthorizedRetrievalCandidates(rows, { payerAddress, subject }),
-    ).toEqual(rows)
+    expect(filterAuthorizedRetrievalCandidates(rows, { payerAddress })).toEqual(
+      rows,
+    )
   })
 
   it('throws 404 when there are no rows', () => {
     expectHttpError(
-      () => filterAuthorizedRetrievalCandidates([], { payerAddress, subject }),
+      () => filterAuthorizedRetrievalCandidates([], { payerAddress }),
       404,
-      `${subject} does not exist or may not have been indexed yet.`,
+      'The requested content does not exist or may not have been indexed yet.',
     )
   })
 
@@ -51,10 +50,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_provider_id: null })],
-          { payerAddress, subject },
+          { payerAddress },
         ),
       404,
-      `${subject} exists but has no associated service provider.`,
+      'The requested content exists but has no associated service provider.',
     )
   })
 
@@ -63,10 +62,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_provider_is_deleted: 1 })],
-          { payerAddress, subject },
+          { payerAddress },
         ),
       404,
-      `${subject} exists but has no associated service provider.`,
+      'The requested content exists but has no associated service provider.',
     )
   })
 
@@ -75,10 +74,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ payer_address: '0xother' })],
-          { payerAddress, subject },
+          { payerAddress },
         ),
       402,
-      `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject}.`,
+      `There is no Filecoin Warm Storage Service deal for payer '${payerAddress}' and the requested content.`,
     )
   })
 
@@ -87,10 +86,9 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates([authorizedRow({ with_cdn: 0 })], {
           payerAddress,
-          subject,
         }),
       402,
-      `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and ${subject} has withCDN=false.`,
+      `The Filecoin Warm Storage Service deal for payer '${payerAddress}' and the requested content has withCDN=false.`,
     )
   })
 
@@ -99,10 +97,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ is_sanctioned: 1 })],
-          { payerAddress, subject },
+          { payerAddress },
         ),
       403,
-      `Wallet '${payerAddress}' is sanctioned and cannot retrieve ${subject}.`,
+      `Wallet '${payerAddress}' is sanctioned and cannot retrieve the requested content.`,
     )
   })
 
@@ -111,10 +109,10 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       () =>
         filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_url: null })],
-          { payerAddress, subject },
+          { payerAddress },
         ),
       404,
-      `No approved service provider found for payer '${payerAddress}' and ${subject}.`,
+      `No approved service provider found for payer '${payerAddress}' and the requested content.`,
     )
   })
 })

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -74,20 +74,13 @@ describe('filterAuthorizedRetrievalRows', () => {
     )
   })
 
-  it('excludes soft-deleted service providers only when requireServiceProviderNotDeleted is set', () => {
-    const rows = [authorizedRow({ service_provider_is_deleted: 1 })]
-    // Without the flag the deleted provider is allowed through.
-    expect(
-      filterAuthorizedRetrievalRows(rows, { payerAddress, messages: MESSAGES }),
-    ).toEqual(rows)
-    // With the flag it is excluded.
+  it('always excludes soft-deleted service providers', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows(rows, {
-          payerAddress,
-          requireServiceProviderNotDeleted: true,
-          messages: MESSAGES,
-        }),
+        filterAuthorizedRetrievalRows(
+          [authorizedRow({ service_provider_is_deleted: 1 })],
+          { payerAddress, messages: MESSAGES },
+        ),
       404,
       MESSAGES.noServiceProvider,
     )

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { filterAuthorizedRetrievalRows } from '../lib/access.js'
+import { filterAuthorizedRetrievalCandidates } from '../lib/access.js'
 
 const MESSAGES = {
   notIndexed: 'not indexed',
@@ -36,20 +36,26 @@ function expectHttpError(fn, status, message) {
   expect(error.message).toBe(message)
 }
 
-describe('filterAuthorizedRetrievalRows', () => {
+describe('filterAuthorizedRetrievalCandidates', () => {
   const payerAddress = '0xabcdef'
 
   it('returns the rows passing every check, matching the payer case-insensitively', () => {
     const rows = [authorizedRow()]
     expect(
-      filterAuthorizedRetrievalRows(rows, { payerAddress, messages: MESSAGES }),
+      filterAuthorizedRetrievalCandidates(rows, {
+        payerAddress,
+        messages: MESSAGES,
+      }),
     ).toEqual(rows)
   })
 
   it('throws 404 when there are no rows', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows([], { payerAddress, messages: MESSAGES }),
+        filterAuthorizedRetrievalCandidates([], {
+          payerAddress,
+          messages: MESSAGES,
+        }),
       404,
       MESSAGES.notIndexed,
     )
@@ -58,7 +64,7 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('throws 404 when no row has a service provider', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows(
+        filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_provider_id: null })],
           { payerAddress, messages: MESSAGES },
         ),
@@ -70,7 +76,7 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('always excludes soft-deleted service providers', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows(
+        filterAuthorizedRetrievalCandidates(
           [authorizedRow({ service_provider_is_deleted: 1 })],
           { payerAddress, messages: MESSAGES },
         ),
@@ -82,7 +88,7 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('throws 402 when the payer has no payment rail', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows(
+        filterAuthorizedRetrievalCandidates(
           [authorizedRow({ payer_address: '0xother' })],
           { payerAddress, messages: MESSAGES },
         ),
@@ -94,7 +100,7 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('throws 402 when CDN is disabled', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows([authorizedRow({ with_cdn: 0 })], {
+        filterAuthorizedRetrievalCandidates([authorizedRow({ with_cdn: 0 })], {
           payerAddress,
           messages: MESSAGES,
         }),
@@ -106,10 +112,13 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('throws 403 when the payer is sanctioned', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows([authorizedRow({ is_sanctioned: 1 })], {
-          payerAddress,
-          messages: MESSAGES,
-        }),
+        filterAuthorizedRetrievalCandidates(
+          [authorizedRow({ is_sanctioned: 1 })],
+          {
+            payerAddress,
+            messages: MESSAGES,
+          },
+        ),
       403,
       MESSAGES.sanctioned,
     )
@@ -118,10 +127,13 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('throws 404 when no service provider is approved (no service_url)', () => {
     expectHttpError(
       () =>
-        filterAuthorizedRetrievalRows([authorizedRow({ service_url: null })], {
-          payerAddress,
-          messages: MESSAGES,
-        }),
+        filterAuthorizedRetrievalCandidates(
+          [authorizedRow({ service_url: null })],
+          {
+            payerAddress,
+            messages: MESSAGES,
+          },
+        ),
       404,
       MESSAGES.noApprovedProvider,
     )

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -10,8 +10,6 @@ const MESSAGES = {
   noApprovedProvider: 'no approved provider',
 }
 
-const IPFS_INDEXING_DISABLED = 'ipfs indexing disabled'
-
 /** A row that passes every check. payer_address is upper-cased on purpose. */
 function authorizedRow(overrides = {}) {
   return {
@@ -19,7 +17,6 @@ function authorizedRow(overrides = {}) {
     service_provider_is_deleted: 0,
     payer_address: '0xABCDEF',
     with_cdn: 1,
-    with_ipfs_indexing: 1,
     is_sanctioned: 0,
     service_url: 'https://sp.example/',
     ...overrides,
@@ -45,11 +42,7 @@ describe('filterAuthorizedRetrievalRows', () => {
   it('returns the rows passing every check, matching the payer case-insensitively', () => {
     const rows = [authorizedRow()]
     expect(
-      filterAuthorizedRetrievalRows(rows, {
-        payerAddress,
-        ipfsIndexingDisabledMessage: IPFS_INDEXING_DISABLED,
-        messages: MESSAGES,
-      }),
+      filterAuthorizedRetrievalRows(rows, { payerAddress, messages: MESSAGES }),
     ).toEqual(rows)
   })
 
@@ -108,29 +101,6 @@ describe('filterAuthorizedRetrievalRows', () => {
       402,
       MESSAGES.cdnDisabled,
     )
-  })
-
-  it('throws 402 when IPFS indexing is required but disabled', () => {
-    expectHttpError(
-      () =>
-        filterAuthorizedRetrievalRows(
-          [authorizedRow({ with_ipfs_indexing: 0 })],
-          {
-            payerAddress,
-            ipfsIndexingDisabledMessage: IPFS_INDEXING_DISABLED,
-            messages: MESSAGES,
-          },
-        ),
-      402,
-      IPFS_INDEXING_DISABLED,
-    )
-  })
-
-  it('does not require IPFS indexing by default', () => {
-    const rows = [authorizedRow({ with_ipfs_indexing: 0 })]
-    expect(
-      filterAuthorizedRetrievalRows(rows, { payerAddress, messages: MESSAGES }),
-    ).toEqual(rows)
   })
 
   it('throws 403 when the payer is sanctioned', () => {

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { filterAuthorizedRetrievalRows } from '../lib/access.js'
+
+const MESSAGES = {
+  notIndexed: 'not indexed',
+  noServiceProvider: 'no service provider',
+  noPaymentRail: 'no payment rail',
+  cdnDisabled: 'cdn disabled',
+  sanctioned: 'sanctioned',
+  noApprovedProvider: 'no approved provider',
+}
+
+const IPFS_INDEXING_DISABLED = 'ipfs indexing disabled'
+
+/** A row that passes every check. payer_address is upper-cased on purpose. */
+function authorizedRow(overrides = {}) {
+  return {
+    service_provider_id: 'sp1',
+    service_provider_is_deleted: 0,
+    payer_address: '0xABCDEF',
+    with_cdn: 1,
+    with_ipfs_indexing: 1,
+    is_sanctioned: 0,
+    service_url: 'https://sp.example/',
+    ...overrides,
+  }
+}
+
+/** @param {() => unknown} fn */
+function expectHttpError(fn, status, message) {
+  let error
+  try {
+    fn()
+  } catch (err) {
+    error = err
+  }
+  expect(error).toBeInstanceOf(Error)
+  expect(error.status).toBe(status)
+  expect(error.message).toBe(message)
+}
+
+describe('filterAuthorizedRetrievalRows', () => {
+  const payerAddress = '0xabcdef'
+
+  it('returns the rows passing every check, matching the payer case-insensitively', () => {
+    const rows = [authorizedRow()]
+    expect(
+      filterAuthorizedRetrievalRows(rows, {
+        payerAddress,
+        ipfsIndexingDisabledMessage: IPFS_INDEXING_DISABLED,
+        messages: MESSAGES,
+      }),
+    ).toEqual(rows)
+  })
+
+  it('throws 404 when there are no rows', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows([], { payerAddress, messages: MESSAGES }),
+      404,
+      MESSAGES.notIndexed,
+    )
+  })
+
+  it('throws 404 when no row has a service provider', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows(
+          [authorizedRow({ service_provider_id: null })],
+          { payerAddress, messages: MESSAGES },
+        ),
+      404,
+      MESSAGES.noServiceProvider,
+    )
+  })
+
+  it('excludes soft-deleted service providers only when requireServiceProviderNotDeleted is set', () => {
+    const rows = [authorizedRow({ service_provider_is_deleted: 1 })]
+    // Without the flag the deleted provider is allowed through.
+    expect(
+      filterAuthorizedRetrievalRows(rows, { payerAddress, messages: MESSAGES }),
+    ).toEqual(rows)
+    // With the flag it is excluded.
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows(rows, {
+          payerAddress,
+          requireServiceProviderNotDeleted: true,
+          messages: MESSAGES,
+        }),
+      404,
+      MESSAGES.noServiceProvider,
+    )
+  })
+
+  it('throws 402 when the payer has no payment rail', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows(
+          [authorizedRow({ payer_address: '0xother' })],
+          { payerAddress, messages: MESSAGES },
+        ),
+      402,
+      MESSAGES.noPaymentRail,
+    )
+  })
+
+  it('throws 402 when CDN is disabled', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows([authorizedRow({ with_cdn: 0 })], {
+          payerAddress,
+          messages: MESSAGES,
+        }),
+      402,
+      MESSAGES.cdnDisabled,
+    )
+  })
+
+  it('throws 402 when IPFS indexing is required but disabled', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows(
+          [authorizedRow({ with_ipfs_indexing: 0 })],
+          {
+            payerAddress,
+            ipfsIndexingDisabledMessage: IPFS_INDEXING_DISABLED,
+            messages: MESSAGES,
+          },
+        ),
+      402,
+      IPFS_INDEXING_DISABLED,
+    )
+  })
+
+  it('does not require IPFS indexing by default', () => {
+    const rows = [authorizedRow({ with_ipfs_indexing: 0 })]
+    expect(
+      filterAuthorizedRetrievalRows(rows, { payerAddress, messages: MESSAGES }),
+    ).toEqual(rows)
+  })
+
+  it('throws 403 when the payer is sanctioned', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows([authorizedRow({ is_sanctioned: 1 })], {
+          payerAddress,
+          messages: MESSAGES,
+        }),
+      403,
+      MESSAGES.sanctioned,
+    )
+  })
+
+  it('throws 404 when no service provider is approved (no service_url)', () => {
+    expectHttpError(
+      () =>
+        filterAuthorizedRetrievalRows([authorizedRow({ service_url: null })], {
+          payerAddress,
+          messages: MESSAGES,
+        }),
+      404,
+      MESSAGES.noApprovedProvider,
+    )
+  })
+})


### PR DESCRIPTION
Targets `serve-ipfs-retrievals`. The Tier 2 PR (#674) is merged and the fetch-wrapper exploration (#676) is closed, so this is the last of the de-duplication series and now stacks directly on the main branch.

Extracts the duplicated authorization cascade from both workers' `store.js` into a shared `filterAuthorizedRetrievalRows` helper in `@filbeam/retrieval`. This is the extraction asked about in https://github.com/filbeam/worker/pull/312#discussion_r2490987001.

## What is shared

The cascade of filter and assert steps, in order: indexed, has a (non-deleted) service provider, has a payment rail for the payer (matched case-insensitively), CDN enabled, optionally IPFS indexing enabled, payer not sanctioned, service provider approved. These predicates and their HTTP status codes are the part most worth keeping consistent, a wrong predicate here is a security or billing bug.

## What stays per-worker

Each worker passes its own error messages, so the API error responses are unchanged and no existing tests needed editing. Each keeps its specific steps and the content-specific SQL.

`ipfs-retriever` additionally requires IPFS indexing and an associated IPFS root CID.

`piece-retriever` additionally excludes soft-deleted providers and enforces the CDN and cache-miss egress quotas.

## Why it fits cleanly now

Both workers already return retrieval candidates, ipfs-retriever started doing so with the service-provider fallback change that is now on the base. Each runs the shared cascade and then maps the surviving rows to candidates, so the two `store.js` validators converge on the same shape. That is what makes the shared helper a clean fit rather than a forced abstraction.

Behavior is preserved exactly, the shared helper has its own unit tests, and the existing store and worker tests pass unchanged.
