### PR TITLE
Extract retrieval error logging into a shared wrapper

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -5,10 +5,10 @@ import {
   isCidDenied,
   BAD_BITS_DENIED_MESSAGE,
   recordRetrieval,
-  logRetrievalError,
   handleFetchRequest,
   selectRetrievalCandidate,
   handleEmptyBodyResponse,
+  withRetrievalErrorLogging,
 } from '@filbeam/retrieval'
 
 import { parseRequest } from '../lib/request.js'
@@ -58,14 +58,21 @@ export default {
       return handleDnsRootRequest(request, env)
     }
 
-    const requestTimestamp = new Date().toISOString()
-    const workerStartedAt = performance.now()
-    const requestCountryCode = request.headers.get('CF-IPCountry')
-
     const { dataSetId, pieceId, ipfsSubpath, ipfsFormat, botName } =
       parseRequest(request, env)
 
-    try {
+    /**
+     * @type {(context: {
+     *   requestTimestamp: string
+     *   workerStartedAt: number
+     *   requestCountryCode: string | null
+     * }) => Promise<Response>}
+     */
+    const handleRetrieval = async ({
+      requestTimestamp,
+      workerStartedAt,
+      requestCountryCode,
+    }) => {
       // Timestamp to measure file retrieval performance (from cache and from SP)
       const fetchStartedAt = performance.now()
 
@@ -177,15 +184,15 @@ export default {
       })
 
       return response
-    } catch (error) {
-      logRetrievalError(env, ctx, error, {
-        requestCountryCode,
-        timestamp: requestTimestamp,
-        botName,
-      })
-
-      throw error
     }
+
+    return withRetrievalErrorLogging(
+      request,
+      env,
+      ctx,
+      { botName },
+      handleRetrieval,
+    )
   },
 }
 

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -5,10 +5,10 @@ import {
   BAD_BITS_DENIED_MESSAGE,
   logRetrievalResult,
   recordRetrieval,
-  logRetrievalError,
   handleFetchRequest,
   selectRetrievalCandidate,
   handleEmptyBodyResponse,
+  withRetrievalErrorLogging,
 } from '@filbeam/retrieval'
 
 import { parseRequest } from '../lib/request.js'
@@ -46,14 +46,21 @@ export default {
       return Response.redirect('https://filbeam.com/', 302)
     }
 
-    const requestTimestamp = new Date().toISOString()
-    const workerStartedAt = performance.now()
-    const requestCountryCode = request.headers.get('CF-IPCountry')
-
     const { payerWalletAddress, pieceCid, botName, validateCacheMissResponse } =
       parseRequest(request, env)
 
-    try {
+    /**
+     * @type {(context: {
+     *   requestTimestamp: string
+     *   workerStartedAt: number
+     *   requestCountryCode: string | null
+     * }) => Promise<Response>}
+     */
+    const handleRetrieval = async ({
+      requestTimestamp,
+      workerStartedAt,
+      requestCountryCode,
+    }) => {
       // Timestamp to measure file retrieval performance (from cache and from SP)
       const fetchStartedAt = performance.now()
 
@@ -237,14 +244,14 @@ export default {
         clientCacheTtl: env.CLIENT_CACHE_TTL,
       })
       return response
-    } catch (error) {
-      logRetrievalError(env, ctx, error, {
-        requestCountryCode,
-        timestamp: requestTimestamp,
-        botName,
-      })
-
-      throw error
     }
+
+    return withRetrievalErrorLogging(
+      request,
+      env,
+      ctx,
+      { botName },
+      handleRetrieval,
+    )
   },
 }

--- a/retrieval/index.js
+++ b/retrieval/index.js
@@ -11,6 +11,7 @@ export * from './lib/http-error.js'
 export * from './lib/origin-cache.js'
 export * from './lib/redirect.js'
 export * from './lib/response-headers.js'
+export * from './lib/retrieval-error-logging.js'
 export * from './lib/stats.js'
 
 export default {

--- a/retrieval/lib/retrieval-error-logging.js
+++ b/retrieval/lib/retrieval-error-logging.js
@@ -1,0 +1,45 @@
+import { logRetrievalError } from './stats.js'
+
+/**
+ * Sets up the per-request retrieval telemetry, runs the handler with it, and
+ * logs a retrieval error (then rethrows) when the handler throws.
+ *
+ * @template T
+ * @param {Request} request
+ * @param {{ DB: D1Database }} env
+ * @param {ExecutionContext} ctx
+ * @param {{ botName: string | undefined }} options
+ * @param {(context: {
+ *   requestTimestamp: string
+ *   workerStartedAt: number
+ *   requestCountryCode: string | null
+ * }) => Promise<T>} handler
+ * @returns {Promise<T>}
+ */
+export async function withRetrievalErrorLogging(
+  request,
+  env,
+  ctx,
+  { botName },
+  handler,
+) {
+  const requestTimestamp = new Date().toISOString()
+  const workerStartedAt = performance.now()
+  const requestCountryCode = request.headers.get('CF-IPCountry')
+
+  try {
+    return await handler({
+      requestTimestamp,
+      workerStartedAt,
+      requestCountryCode,
+    })
+  } catch (error) {
+    logRetrievalError(env, ctx, error, {
+      requestCountryCode,
+      timestamp: requestTimestamp,
+      botName,
+    })
+
+    throw error
+  }
+}

--- a/retrieval/test/retrieval-error-logging.test.js
+++ b/retrieval/test/retrieval-error-logging.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { withRetrievalErrorLogging } from '../lib/retrieval-error-logging.js'
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from 'cloudflare:test'
+
+const request = new Request('https://example.com/', {
+  headers: { 'CF-IPCountry': 'US' },
+})
+
+describe('withRetrievalErrorLogging', () => {
+  it('passes the per-request telemetry context to the handler', async () => {
+    const ctx = createExecutionContext()
+    let received
+    const result = await withRetrievalErrorLogging(
+      request,
+      env,
+      ctx,
+      { botName: undefined },
+      async (context) => {
+        received = context
+        return 'ok'
+      },
+    )
+    await waitOnExecutionContext(ctx)
+
+    expect(result).toBe('ok')
+    expect(received).toEqual({
+      requestTimestamp: expect.any(String),
+      workerStartedAt: expect.any(Number),
+      requestCountryCode: 'US',
+    })
+  })
+
+  it('logs a retrieval error and rethrows when the handler throws', async () => {
+    const ctx = createExecutionContext()
+    const error = Object.assign(new Error('Not Found'), { status: 404 })
+
+    await expect(
+      withRetrievalErrorLogging(
+        request,
+        env,
+        ctx,
+        { botName: 'bot1' },
+        async () => {
+          throw error
+        },
+      ),
+    ).rejects.toBe(error)
+    await waitOnExecutionContext(ctx)
+
+    const log = await env.DB.prepare(
+      `SELECT response_status, egress_bytes, data_set_id, request_country_code, bot_name
+       FROM retrieval_logs WHERE bot_name = ? AND response_status = 404`,
+    )
+      .bind('bot1')
+      .first()
+
+    expect(log).toEqual({
+      response_status: 404,
+      egress_bytes: null,
+      data_set_id: null,
+      request_country_code: 'US',
+      bot_name: 'bot1',
+    })
+  })
+})


### PR DESCRIPTION
Both retrieval workers set up the same per-request telemetry (`requestTimestamp`, `workerStartedAt`, `requestCountryCode`) and wrapped their retrieval body in an identical `try/catch` that logged a retrieval error and rethrew. This extracts that into `withRetrievalErrorLogging` in `@filbeam/retrieval`.

## Changes

- `retrieval/lib/retrieval-error-logging.js` exports `withRetrievalErrorLogging(request, env, ctx, { botName }, handler)`. It builds the telemetry context, passes it to the handler, and logs a retrieval error (then rethrows) when the handler throws.
- `piece-retriever` and `ipfs-retriever` move their retrieval body into a `handleRetrieval` handler and pass it to the wrapper. `parseRequest` stays outside the wrapper, so request-validation errors are not retrieval-logged, matching today's behavior.