### PR TITLE
Extract the proxied retrieval response into buildRetrievalResponse

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -1,7 +1,7 @@
 import {
   isValidEthereumAddress,
   httpAssert,
-  setRetrievalResponseHeaders,
+  buildRetrievalResponse,
   isCidDenied,
   BAD_BITS_DENIED_MESSAGE,
   recordRetrieval,
@@ -166,17 +166,13 @@ export default {
 
       // Return immediately, proxying the transformed response. The headers
       // already carry the CAR-to-raw adjustments from processIpfsResponse.
-      const response = new Response(returnedStream, {
+      return buildRetrievalResponse(env, {
+        body: returnedStream,
         status: originResponse.status,
         statusText: originResponse.statusText,
         headers: responseHeaders,
-      })
-      setRetrievalResponseHeaders(response, {
         dataSetId: candidate.dataSetId,
-        clientCacheTtl: env.CLIENT_CACHE_TTL,
       })
-
-      return response
     } catch (error) {
       logRetrievalError(env, ctx, error, {
         requestCountryCode,

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -1,6 +1,6 @@
 import {
   httpAssert,
-  setRetrievalResponseHeaders,
+  buildRetrievalResponse,
   isCidDenied,
   BAD_BITS_DENIED_MESSAGE,
   logRetrievalResult,
@@ -227,16 +227,13 @@ export default {
       )
 
       // Return immediately, proxying the transformed response
-      const response = new Response(returnedStream.readable, {
+      return buildRetrievalResponse(env, {
+        body: returnedStream.readable,
         status: retrievalResult.response.status,
         statusText: retrievalResult.response.statusText,
         headers: retrievalResult.response.headers,
-      })
-      setRetrievalResponseHeaders(response, {
         dataSetId: retrievalCandidate.dataSetId,
-        clientCacheTtl: env.CLIENT_CACHE_TTL,
       })
-      return response
     } catch (error) {
       logRetrievalError(env, ctx, error, {
         requestCountryCode,

--- a/retrieval/lib/response-headers.js
+++ b/retrieval/lib/response-headers.js
@@ -17,3 +17,29 @@ export function setRetrievalResponseHeaders(
   response.headers.set('X-Data-Set-ID', dataSetId)
   response.headers.set('Cache-Control', `public, max-age=${clientCacheTtl}`)
 }
+
+/**
+ * Builds the proxied retrieval response: a new response carrying the given body
+ * and the upstream status and headers, with the standard retrieval response
+ * headers applied via {@link setRetrievalResponseHeaders}.
+ *
+ * @param {{ CLIENT_CACHE_TTL: number }} env
+ * @param {object} params
+ * @param {BodyInit | null} params.body
+ * @param {number} params.status
+ * @param {string} params.statusText
+ * @param {HeadersInit} params.headers
+ * @param {string} params.dataSetId
+ * @returns {Response}
+ */
+export function buildRetrievalResponse(
+  env,
+  { body, status, statusText, headers, dataSetId },
+) {
+  const response = new Response(body, { status, statusText, headers })
+  setRetrievalResponseHeaders(response, {
+    dataSetId,
+    clientCacheTtl: env.CLIENT_CACHE_TTL,
+  })
+  return response
+}

--- a/retrieval/test/response-headers.test.js
+++ b/retrieval/test/response-headers.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { setRetrievalResponseHeaders } from '../lib/response-headers.js'
+import {
+  setRetrievalResponseHeaders,
+  buildRetrievalResponse,
+} from '../lib/response-headers.js'
 
 describe('setRetrievalResponseHeaders', () => {
   it('sets the CSP, data set id and client cache headers', () => {
@@ -17,5 +20,33 @@ describe('setRetrievalResponseHeaders', () => {
     expect(response.headers.get('Cache-Control')).toBe(
       'public, max-age=31536000',
     )
+  })
+})
+
+describe('buildRetrievalResponse', () => {
+  it('proxies the body, status and headers with retrieval headers applied', async () => {
+    const headers = new Headers({ 'Content-Type': 'text/plain' })
+    const response = buildRetrievalResponse(
+      { CLIENT_CACHE_TTL: 31536000 },
+      {
+        body: 'hello',
+        status: 206,
+        statusText: 'Partial Content',
+        headers,
+        dataSetId: '42',
+      },
+    )
+
+    expect(response.status).toBe(206)
+    expect(response.statusText).toBe('Partial Content')
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(response.headers.get('X-Data-Set-ID')).toBe('42')
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=31536000',
+    )
+    expect(response.headers.get('Content-Security-Policy')).toMatch(
+      /^default-src 'self'/,
+    )
+    expect(await response.text()).toBe('hello')
   })
 })


### PR DESCRIPTION
Both retrieval workers ended by building a new response from the streamed body and the upstream status, status text, and headers, then applying the retrieval response headers. This extracts that into `buildRetrievalResponse` in `@filbeam/retrieval`.

## Changes

- `retrieval/lib/response-headers.js` exports `buildRetrievalResponse(env, { body, status, statusText, headers, dataSetId })`, which constructs the proxied response and applies the retrieval response headers via `setRetrievalResponseHeaders`.
- `piece-retriever` and `ipfs-retriever` call the shared helper. The body and headers differ per worker (the raw response for piece, the `processIpfsResponse` output for ipfs) and are passed as arguments.