### PR TITLE
Log a 900 retrieval result when the ipfs response stream errors

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -4,6 +4,7 @@ import {
   setRetrievalResponseHeaders,
   isCidDenied,
   BAD_BITS_DENIED_MESSAGE,
+  logRetrievalResult,
   recordRetrieval,
   logRetrievalError,
   handleFetchRequest,
@@ -134,33 +135,49 @@ export default {
 
       ctx.waitUntil(
         (async () => {
-          const egressBytes = await measureStreamedEgress(reader)
-          const lastByteFetchedAt = performance.now()
+          try {
+            const egressBytes = await measureStreamedEgress(reader)
+            const lastByteFetchedAt = performance.now()
 
-          // The client is served the raw bytes (`egressBytes`). On a cache miss
-          // the worker fetched a CAR from the service provider, which is larger
-          // than the raw bytes when converting from CAR to raw. The cache-miss
-          // egress is charged for that CAR size. When the body is passed through
-          // unchanged (e.g. `?format=car`), the two values are equal.
-          const cacheMissEgressBytes = originEgressBytes ?? egressBytes
+            // The client is served the raw bytes (`egressBytes`). On a cache
+            // miss the worker fetched a CAR from the service provider, which is
+            // larger than the raw bytes when converting from CAR to raw. The
+            // cache-miss egress is charged for that CAR size. When the body is
+            // passed through unchanged (e.g. `?format=car`), the two are equal.
+            const cacheMissEgressBytes = originEgressBytes ?? egressBytes
 
-          await recordRetrieval(env, {
-            cacheMiss,
-            cacheMissResponseValid: null,
-            responseStatus: originResponse.status,
-            egressBytes,
-            cacheMissEgressBytes,
-            requestCountryCode,
-            timestamp: requestTimestamp,
-            performanceStats: {
-              fetchTtfb: firstByteAt - fetchStartedAt,
-              fetchTtlb: lastByteFetchedAt - fetchStartedAt,
-              workerTtfb: firstByteAt - workerStartedAt,
-            },
-            dataSetId: candidate.dataSetId,
-            botName,
-            enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
-          })
+            await recordRetrieval(env, {
+              cacheMiss,
+              cacheMissResponseValid: null,
+              responseStatus: originResponse.status,
+              egressBytes,
+              cacheMissEgressBytes,
+              requestCountryCode,
+              timestamp: requestTimestamp,
+              performanceStats: {
+                fetchTtfb: firstByteAt - fetchStartedAt,
+                fetchTtlb: lastByteFetchedAt - fetchStartedAt,
+                workerTtfb: firstByteAt - workerStartedAt,
+              },
+              dataSetId: candidate.dataSetId,
+              botName,
+              enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
+            })
+          } catch (err) {
+            console.error('Error in server stream:', err)
+
+            await logRetrievalResult(env, {
+              cacheMiss,
+              cacheMissResponseValid: null,
+              responseStatus: 900,
+              egressBytes: 0,
+              cacheMissEgressBytes: 0,
+              requestCountryCode,
+              timestamp: requestTimestamp,
+              dataSetId: candidate.dataSetId,
+              botName,
+            })
+          }
         })(),
       )
 

--- a/ipfs-retriever/test/retriever.test.js
+++ b/ipfs-retriever/test/retriever.test.js
@@ -523,6 +523,44 @@ describe('retriever.fetch', () => {
     assert.strictEqual(readOutput.results[0].egress_bytes, 0)
   })
 
+  it('logs a 900 retrieval result when the response stream errors', async () => {
+    const erroringBody = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]))
+        controller.error(new Error('stream boom'))
+      },
+    })
+    const mockRetrieveIpfsContent = vi.fn().mockResolvedValue({
+      response: new Response(erroringBody, { status: 200 }),
+      cacheMiss: true,
+    })
+
+    const ctx = createExecutionContext()
+    // `?format=car` passes the body through unchanged, so the erroring stream
+    // reaches the egress measurement.
+    const req = withRequest(
+      realDataSetId,
+      realPieceId,
+      'GET',
+      {},
+      {
+        format: 'car',
+      },
+    )
+    const res = await worker.fetch(req, env, ctx, {
+      retrieveIpfsContent: mockRetrieveIpfsContent,
+    })
+    expect(res.status).toBe(200)
+    await waitOnExecutionContext(ctx)
+
+    const log = await env.DB.prepare(
+      'SELECT response_status, egress_bytes FROM retrieval_logs WHERE data_set_id = ? AND response_status = 900',
+    )
+      .bind(String(realDataSetId))
+      .first()
+    expect(log).toEqual({ response_status: 900, egress_bytes: 0 })
+  })
+
   // FIXME - update the test to retrieve real IPFS content
   // This is blocked by Curio not indexing CAR files inside PDP deals yet
   it.skip(


### PR DESCRIPTION
The ipfs streaming task (`ctx.waitUntil`) had no error handling, so a mid-stream failure (e.g. an invalid block during CAR-to-raw conversion, or a service provider aborting the response) produced no `retrieval_logs` entry. The piece retriever already logs a `900` result in this case.

## Changes

- `ipfs-retriever` wraps the streaming task in a try/catch that logs a `900` retrieval result on failure, mirroring the piece retriever.
- Added a test that drives a passed-through (`?format=car`) response whose body stream errors and asserts the `900` log row.

Unlike the piece retriever, which tracks bytes incrementally and can log the partial count, ipfs measures egress with `measureStreamedEgress`, which returns only the total. On error the partial count is not available, so the `900` row logs `egress_bytes: 0`.