### PR TITLE
Build retrieval candidate queries from a shared helper

### DIFF
--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -11,7 +11,7 @@ const SELECT_CANDIDATES_BY_CID = buildRetrievalCandidateQuery({
     'pieces.ipfs_root_cid',
     'data_sets.with_ipfs_indexing',
   ],
-  where: 'pieces.ipfs_root_cid = ? AND pieces.is_deleted IS FALSE',
+  where: 'pieces.ipfs_root_cid = ?',
 })
 
 /**

--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -2,33 +2,17 @@ import { bigIntToBase32 } from './bigint-util.js'
 import {
   httpAssert,
   filterAuthorizedRetrievalCandidates,
+  buildRetrievalCandidateQuery,
 } from '@filbeam/retrieval'
 
-const SELECT_CANDIDATES_BY_CID = `
-   SELECT
-     pieces.id as piece_id,
-     pieces.data_set_id,
-     pieces.ipfs_root_cid,
-     data_sets.service_provider_id,
-     data_sets.payer_address,
-     data_sets.with_cdn,
-     data_sets.with_ipfs_indexing,
-     data_set_egress_quotas.cdn_egress_quota,
-     data_set_egress_quotas.cache_miss_egress_quota,
-     service_providers.service_url,
-     service_providers.is_deleted as service_provider_is_deleted,
-     wallet_details.is_sanctioned
-   FROM pieces
-   LEFT OUTER JOIN data_sets
-     ON pieces.data_set_id = data_sets.id
-   LEFT OUTER JOIN data_set_egress_quotas
-     ON pieces.data_set_id = data_set_egress_quotas.data_set_id
-   LEFT OUTER JOIN service_providers
-     ON data_sets.service_provider_id = service_providers.id
-   LEFT OUTER JOIN wallet_details
-     ON data_sets.payer_address = wallet_details.address
-   WHERE pieces.ipfs_root_cid = ?
- `
+const SELECT_CANDIDATES_BY_CID = buildRetrievalCandidateQuery({
+  extraColumns: [
+    'pieces.id AS piece_id',
+    'pieces.ipfs_root_cid',
+    'data_sets.with_ipfs_indexing',
+  ],
+  where: 'pieces.ipfs_root_cid = ? AND pieces.is_deleted IS FALSE',
+})
 
 /**
  * Validates query results and returns every approved retrieval candidate. This

--- a/ipfs-retriever/test/store.test.js
+++ b/ipfs-retriever/test/store.test.js
@@ -57,6 +57,33 @@ describe('getRetrievalCandidatesByWalletAndCid', () => {
     )
   })
 
+  it('excludes deleted pieces', async () => {
+    const dataSetId = 'test-set-deleted'
+    const ipfsRootCid = 'bafk4deleted'
+    const payerAddress = '0x1234567890abcdef1234567890abcdef12345678'
+
+    await env.DB.prepare(
+      'INSERT INTO data_sets (id, service_provider_id, payer_address, with_cdn, with_ipfs_indexing) VALUES (?, ?, ?, ?, ?)',
+    )
+      .bind(dataSetId, APPROVED_SERVICE_PROVIDER_ID, payerAddress, true, true)
+      .run()
+    await env.DB.prepare(
+      'INSERT INTO pieces (id, data_set_id, cid, ipfs_root_cid, is_deleted) VALUES (?, ?, ?, ?, ?)',
+    )
+      .bind('piece-deleted', dataSetId, 'baga4deleted', ipfsRootCid, true)
+      .run()
+
+    await assert.rejects(
+      async () =>
+        await getRetrievalCandidatesByWalletAndCid(
+          env,
+          payerAddress,
+          ipfsRootCid,
+        ),
+      /does not exist/,
+    )
+  })
+
   it('throws error if data_set_id exists but has no associated service provider', async () => {
     const cid = 'cid-no-owner'
     const dataSetId = 'data-set-no-owner'

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -1,4 +1,7 @@
-import { filterAuthorizedRetrievalCandidates } from '@filbeam/retrieval'
+import {
+  filterAuthorizedRetrievalCandidates,
+  buildRetrievalCandidateQuery,
+} from '@filbeam/retrieval'
 
 /**
  * Retrieves the provider and data set id for a given root CID.
@@ -26,29 +29,9 @@ export async function getRetrievalCandidatesAndValidatePayer(
   pieceCid,
   enforceEgressQuota = false,
 ) {
-  const query = `
-   SELECT 
-    pieces.data_set_id, 
-    data_sets.service_provider_id, 
-    data_sets.payer_address, 
-    data_sets.with_cdn,
-    data_set_egress_quotas.cdn_egress_quota, 
-    data_set_egress_quotas.cache_miss_egress_quota,
-    service_providers.service_url, 
-    service_providers.is_deleted as service_provider_is_deleted,
-    wallet_details.is_sanctioned
-   FROM pieces
-   LEFT OUTER JOIN data_sets
-     ON pieces.data_set_id = data_sets.id
-   LEFT OUTER JOIN data_set_egress_quotas
-     ON pieces.data_set_id = data_set_egress_quotas.data_set_id
-   LEFT OUTER JOIN service_providers
-     ON data_sets.service_provider_id = service_providers.id
-   LEFT OUTER JOIN wallet_details
-     ON data_sets.payer_address = wallet_details.address
-   WHERE
-     pieces.cid = ? AND pieces.is_deleted IS FALSE
- `
+  const query = buildRetrievalCandidateQuery({
+    where: 'pieces.cid = ? AND pieces.is_deleted IS FALSE',
+  })
 
   const results = /**
    * @type {{

--- a/piece-retriever/lib/store.js
+++ b/piece-retriever/lib/store.js
@@ -30,7 +30,7 @@ export async function getRetrievalCandidatesAndValidatePayer(
   enforceEgressQuota = false,
 ) {
   const query = buildRetrievalCandidateQuery({
-    where: 'pieces.cid = ? AND pieces.is_deleted IS FALSE',
+    where: 'pieces.cid = ?',
   })
 
   const results = /**

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -115,3 +115,45 @@ export function filterAuthorizedRetrievalCandidates(
 
   return withSufficientCacheMissQuota
 }
+
+/**
+ * Builds the SELECT that joins pieces, data_sets, data_set_egress_quotas,
+ * service_providers and wallet_details and returns the columns the
+ * authorization cascade in {@link filterAuthorizedRetrievalCandidates} reads.
+ * Callers supply the lookup-specific `where` clause and any extra columns.
+ *
+ * @param {object} options
+ * @param {string[]} [options.extraColumns] - Extra columns to select, in
+ *   addition to the ones the cascade reads.
+ * @param {string} options.where - The `WHERE` clause, without the `WHERE`
+ *   keyword.
+ * @returns {string}
+ */
+export function buildRetrievalCandidateQuery({ extraColumns = [], where }) {
+  const columns = [
+    'pieces.data_set_id',
+    'data_sets.service_provider_id',
+    'data_sets.payer_address',
+    'data_sets.with_cdn',
+    'data_set_egress_quotas.cdn_egress_quota',
+    'data_set_egress_quotas.cache_miss_egress_quota',
+    'service_providers.service_url',
+    'service_providers.is_deleted AS service_provider_is_deleted',
+    'wallet_details.is_sanctioned',
+    ...extraColumns,
+  ]
+
+  return `
+    SELECT ${columns.join(', ')}
+    FROM pieces
+    LEFT OUTER JOIN data_sets
+      ON pieces.data_set_id = data_sets.id
+    LEFT OUTER JOIN data_set_egress_quotas
+      ON pieces.data_set_id = data_set_egress_quotas.data_set_id
+    LEFT OUTER JOIN service_providers
+      ON data_sets.service_provider_id = service_providers.id
+    LEFT OUTER JOIN wallet_details
+      ON data_sets.payer_address = wallet_details.address
+    WHERE ${where}
+  `
+}

--- a/retrieval/lib/access.js
+++ b/retrieval/lib/access.js
@@ -122,11 +122,13 @@ export function filterAuthorizedRetrievalCandidates(
  * authorization cascade in {@link filterAuthorizedRetrievalCandidates} reads.
  * Callers supply the lookup-specific `where` clause and any extra columns.
  *
+ * Deleted pieces are always excluded.
+ *
  * @param {object} options
  * @param {string[]} [options.extraColumns] - Extra columns to select, in
  *   addition to the ones the cascade reads.
- * @param {string} options.where - The `WHERE` clause, without the `WHERE`
- *   keyword.
+ * @param {string} options.where - The lookup condition, without the `WHERE`
+ *   keyword. It is combined with a filter that excludes deleted pieces.
  * @returns {string}
  */
 export function buildRetrievalCandidateQuery({ extraColumns = [], where }) {
@@ -154,6 +156,6 @@ export function buildRetrievalCandidateQuery({ extraColumns = [], where }) {
       ON data_sets.service_provider_id = service_providers.id
     LEFT OUTER JOIN wallet_details
       ON data_sets.payer_address = wallet_details.address
-    WHERE ${where}
+    WHERE (${where}) AND pieces.is_deleted IS FALSE
   `
 }

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -188,7 +188,17 @@ describe('buildRetrievalCandidateQuery', () => {
     expect(query).toContain(
       'LEFT OUTER JOIN data_sets\n      ON pieces.data_set_id = data_sets.id',
     )
-    expect(query).toContain('WHERE pieces.cid = ?')
+    expect(query).toContain('WHERE (pieces.cid = ?)')
+  })
+
+  it('always excludes deleted pieces', () => {
+    const query = buildRetrievalCandidateQuery({
+      where: 'pieces.cid = ?',
+    })
+
+    expect(query).toContain(
+      'WHERE (pieces.cid = ?) AND pieces.is_deleted IS FALSE',
+    )
   })
 
   it('appends the extra columns', () => {
@@ -199,6 +209,6 @@ describe('buildRetrievalCandidateQuery', () => {
 
     expect(query).toContain('pieces.id AS piece_id')
     expect(query).toContain('pieces.ipfs_root_cid')
-    expect(query).toContain('WHERE pieces.ipfs_root_cid = ?')
+    expect(query).toContain('WHERE (pieces.ipfs_root_cid = ?)')
   })
 })

--- a/retrieval/test/access.test.js
+++ b/retrieval/test/access.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { filterAuthorizedRetrievalCandidates } from '../lib/access.js'
+import {
+  filterAuthorizedRetrievalCandidates,
+  buildRetrievalCandidateQuery,
+} from '../lib/access.js'
 
 const payerAddress = '0xabcdef'
 
@@ -159,5 +162,43 @@ describe('filterAuthorizedRetrievalCandidates', () => {
       402,
       `Cache miss egress quota exhausted for payer '${payerAddress}' and the requested content. Please top up your cache miss egress quota.`,
     )
+  })
+})
+
+describe('buildRetrievalCandidateQuery', () => {
+  it('selects the cascade columns, the joins, and the given where clause', () => {
+    const query = buildRetrievalCandidateQuery({
+      where: 'pieces.cid = ?',
+    })
+
+    for (const column of [
+      'pieces.data_set_id',
+      'data_sets.service_provider_id',
+      'data_sets.payer_address',
+      'data_sets.with_cdn',
+      'data_set_egress_quotas.cdn_egress_quota',
+      'data_set_egress_quotas.cache_miss_egress_quota',
+      'service_providers.service_url',
+      'service_providers.is_deleted AS service_provider_is_deleted',
+      'wallet_details.is_sanctioned',
+    ]) {
+      expect(query).toContain(column)
+    }
+    expect(query).toContain('FROM pieces')
+    expect(query).toContain(
+      'LEFT OUTER JOIN data_sets\n      ON pieces.data_set_id = data_sets.id',
+    )
+    expect(query).toContain('WHERE pieces.cid = ?')
+  })
+
+  it('appends the extra columns', () => {
+    const query = buildRetrievalCandidateQuery({
+      extraColumns: ['pieces.id AS piece_id', 'pieces.ipfs_root_cid'],
+      where: 'pieces.ipfs_root_cid = ?',
+    })
+
+    expect(query).toContain('pieces.id AS piece_id')
+    expect(query).toContain('pieces.ipfs_root_cid')
+    expect(query).toContain('WHERE pieces.ipfs_root_cid = ?')
   })
 })


### PR DESCRIPTION
Both retrieval workers hand-wrote the same `SELECT` joining `pieces`, `data_sets`, `data_set_egress_quotas`, `service_providers` and `wallet_details`, selecting the nine columns the shared `filterAuthorizedRetrievalCandidates` cascade reads. The join graph and that column list are one contract (they map to the `RetrievalCandidateRow` typedef), so they were duplicated across both `store.js` files and could drift from the cascade.

## Changes

- `retrieval/lib/access.js` exports `buildRetrievalCandidateQuery({ extraColumns, where })`, which returns the shared `SELECT` + joins and lets each worker pass its extra columns and `WHERE`.
- `piece-retriever` and `ipfs-retriever` build their candidate query from the helper. ipfs passes `piece_id`, `ipfs_root_cid` and `with_ipfs_indexing` as extra columns.

## Behavioral change

The ipfs candidate query now also filters `pieces.is_deleted IS FALSE`, so deleted pieces are excluded, matching the piece retriever. Added a store test covering it.