### PR TITLE
Combine the Bad Bits check into assertCidNotDenied

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -2,8 +2,7 @@ import {
   isValidEthereumAddress,
   httpAssert,
   setRetrievalResponseHeaders,
-  isCidDenied,
-  BAD_BITS_DENIED_MESSAGE,
+  assertCidNotDenied,
   logRetrievalResult,
   recordRetrieval,
   logRetrievalError,
@@ -80,8 +79,7 @@ export default {
       const ipfsRootCid = candidates[0].ipfsRootCid
 
       // Now check Bad Bits with the ipfsRootCid we got from the database
-      const isBadBit = await isCidDenied(env, ipfsRootCid)
-      httpAssert(!isBadBit, 404, BAD_BITS_DENIED_MESSAGE)
+      await assertCidNotDenied(env, ipfsRootCid)
 
       const {
         failureResponse,

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -1,8 +1,7 @@
 import {
   httpAssert,
   setRetrievalResponseHeaders,
-  isCidDenied,
-  BAD_BITS_DENIED_MESSAGE,
+  assertCidNotDenied,
   logRetrievalResult,
   recordRetrieval,
   logRetrievalError,
@@ -57,17 +56,15 @@ export default {
       // Timestamp to measure file retrieval performance (from cache and from SP)
       const fetchStartedAt = performance.now()
 
-      const [retrievalCandidates, isBadBit] = await Promise.all([
+      const [retrievalCandidates] = await Promise.all([
         getRetrievalCandidatesAndValidatePayer(
           env,
           payerWalletAddress,
           pieceCid,
           env.ENFORCE_EGRESS_QUOTA,
         ),
-        isCidDenied(env, pieceCid),
+        assertCidNotDenied(env, pieceCid),
       ])
-
-      httpAssert(!isBadBit, 404, BAD_BITS_DENIED_MESSAGE)
 
       httpAssert(
         retrievalCandidates.length > 0,

--- a/retrieval/lib/bad-bits-util.js
+++ b/retrieval/lib/bad-bits-util.js
@@ -13,9 +13,6 @@ export async function getBadBitsEntry(cid) {
   return hashHex
 }
 
-export const BAD_BITS_DENIED_MESSAGE =
-  'The requested CID was flagged by the Bad Bits Denylist at https://badbits.dwebops.pub'
-
 /**
  * Looks up whether a CID is on the Bad Bits denylist stored in KV.
  *
@@ -39,5 +36,9 @@ export async function isCidDenied(env, cid) {
  * @returns {Promise<void>}
  */
 export async function assertCidNotDenied(env, cid) {
-  httpAssert(!(await isCidDenied(env, cid)), 404, BAD_BITS_DENIED_MESSAGE)
+  httpAssert(
+    !(await isCidDenied(env, cid)),
+    404,
+    'The requested CID was flagged by the Bad Bits Denylist at https://badbits.dwebops.pub',
+  )
 }

--- a/retrieval/lib/bad-bits-util.js
+++ b/retrieval/lib/bad-bits-util.js
@@ -1,3 +1,5 @@
+import { httpAssert } from './http-assert.js'
+
 /**
  * @param {string} cid
  * @returns {Promise<string>} Bad Bits entry in the legacy double-hash format
@@ -27,4 +29,15 @@ export async function isCidDenied(env, cid) {
     { type: 'json' },
   )
   return Boolean(entry)
+}
+
+/**
+ * Throws a `404` when the CID is on the Bad Bits denylist.
+ *
+ * @param {{ BAD_BITS_KV: KVNamespace }} env
+ * @param {string} cid
+ * @returns {Promise<void>}
+ */
+export async function assertCidNotDenied(env, cid) {
+  httpAssert(!(await isCidDenied(env, cid)), 404, BAD_BITS_DENIED_MESSAGE)
 }

--- a/retrieval/test/bad-bits-util.test.js
+++ b/retrieval/test/bad-bits-util.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { getBadBitsEntry, isCidDenied } from '../lib/bad-bits-util.js'
+import {
+  getBadBitsEntry,
+  isCidDenied,
+  assertCidNotDenied,
+} from '../lib/bad-bits-util.js'
 
 describe('getBadBitsEntry', () => {
   it('creates entry in the legacy double-hash format', async () => {
@@ -35,5 +39,21 @@ describe('isCidDenied', () => {
   it('returns false when the CID is not on the denylist', async () => {
     const env = { BAD_BITS_KV: { get: async () => null } }
     expect(await isCidDenied(env, 'bafytest')).toBe(false)
+  })
+})
+
+describe('assertCidNotDenied', () => {
+  it('throws a 404 when the CID is on the denylist', async () => {
+    const env = { BAD_BITS_KV: { get: async () => ({}) } }
+    await expect(assertCidNotDenied(env, 'bafytest')).rejects.toMatchObject({
+      status: 404,
+      message:
+        'The requested CID was flagged by the Bad Bits Denylist at https://badbits.dwebops.pub',
+    })
+  })
+
+  it('resolves when the CID is not on the denylist', async () => {
+    const env = { BAD_BITS_KV: { get: async () => null } }
+    await expect(assertCidNotDenied(env, 'bafytest')).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
Both retrieval workers called `isCidDenied` and then `httpAssert(!isBadBit, 404, ...)` with the Bad Bits denial message. This wraps the two into a single `assertCidNotDenied` call.

## Changes

- `retrieval/lib/bad-bits-util.js` exports `assertCidNotDenied(env, cid)`, which throws a `404` with the Bad Bits denial message (inlined) when the CID is on the denylist. `isCidDenied` stays exported as the building block; `BAD_BITS_DENIED_MESSAGE` is no longer exported.
- `ipfs-retriever` calls `await assertCidNotDenied(env, ipfsRootCid)` in place of the two-step check.
- `piece-retriever` passes `assertCidNotDenied(env, pieceCid)` into the existing `Promise.all` alongside the candidate lookup, so the denylist check still runs in parallel.

In `piece-retriever`, the denylist check is now a rejecting promise inside the `Promise.all` rather than a boolean asserted afterwards. If both the denylist check and the candidate lookup fail, `Promise.all` now rejects with whichever settles first, where previously the candidate-lookup error always took precedence. Both still surface a 404 for a denied CID with valid candidates.