### PR TITLE
Handle egress measurement and logging in handleFetchRequest

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -1,20 +1,15 @@
 import {
   isValidEthereumAddress,
   httpAssert,
-  setRetrievalResponseHeaders,
   assertCidNotDenied,
-  logRetrievalResult,
-  recordRetrieval,
   logRetrievalError,
   handleFetchRequest,
   selectRetrievalCandidate,
-  handleEmptyBodyResponse,
 } from '@filbeam/retrieval'
 
 import { parseRequest } from '../lib/request.js'
 import {
   retrieveIpfsContent as defaultRetrieveIpfsContent,
-  measureStreamedEgress,
   processIpfsResponse,
 } from '../lib/retrieval.js'
 import {
@@ -32,7 +27,7 @@ export default {
    * @returns
    */
   async fetch(request, env, ctx, options) {
-    return handleFetchRequest(request, () =>
+    return handleFetchRequest(request, env, ctx, () =>
       this._fetch(request, env, ctx, options),
     )
   },
@@ -43,7 +38,9 @@ export default {
    * @param {ExecutionContext} ctx
    * @param {object} options
    * @param {typeof defaultRetrieveIpfsContent} [options.retrieveIpfsContent]
-   * @returns
+   * @returns {Promise<
+   *   Response | import('@filbeam/retrieval').RetrievalOutcome
+   * >}
    */
   async _fetch(
     request,
@@ -114,90 +111,36 @@ export default {
         signal: request.signal,
       })
 
-      if (!responseBody) {
-        return handleEmptyBodyResponse(env, ctx, {
-          response: originResponse,
-          cacheMiss,
-          dataSetId: candidate.dataSetId,
-          requestCountryCode,
-          timestamp: requestTimestamp,
-          botName,
-        })
-      }
+      // When converting CAR to raw, the headers already carry the CAR-to-raw
+      // adjustments. A null body (e.g. a HEAD request) is served as-is.
+      const response = responseBody
+        ? new Response(responseBody, {
+            status: originResponse.status,
+            statusText: originResponse.statusText,
+            headers: responseHeaders,
+          })
+        : originResponse
 
-      // Stream and count bytes
-      // We create two identical streams, one for the egress measurement and the other for returning the response as soon as possible
-      const [returnedStream, egressMeasurementStream] = responseBody.tee()
-      const reader = egressMeasurementStream.getReader()
-      const firstByteAt = performance.now()
-
-      ctx.waitUntil(
-        (async () => {
-          try {
-            const egressBytes = await measureStreamedEgress(reader)
-            const lastByteFetchedAt = performance.now()
-
-            // The client is served the raw bytes (`egressBytes`). On a cache
-            // miss the worker fetched a CAR from the service provider, which is
-            // larger than the raw bytes when converting from CAR to raw. The
-            // cache-miss egress is charged for that CAR size. When the body is
-            // passed through unchanged (e.g. `?format=car`), the two are equal.
-            const cacheMissEgressBytes = originEgressBytes ?? egressBytes
-
-            await recordRetrieval(env, {
-              cacheMiss,
-              // Charge the cache-miss egress quota for every cache miss: the
-              // worker fetched the CAR from the service provider whether it was
-              // converted to raw or passed through (`?format=car`). Reaching
-              // here means the response streamed successfully (a converted CAR
-              // is validated during conversion, so an invalid one never gets
-              // here).
-              cacheMissResponseValid: cacheMiss ? true : null,
-              responseStatus: originResponse.status,
-              egressBytes,
-              cacheMissEgressBytes,
-              requestCountryCode,
-              timestamp: requestTimestamp,
-              performanceStats: {
-                fetchTtfb: firstByteAt - fetchStartedAt,
-                fetchTtlb: lastByteFetchedAt - fetchStartedAt,
-                workerTtfb: firstByteAt - workerStartedAt,
-              },
-              dataSetId: candidate.dataSetId,
-              botName,
-              enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
-            })
-          } catch (err) {
-            console.error('Error in server stream:', err)
-
-            await logRetrievalResult(env, {
-              cacheMiss,
-              cacheMissResponseValid: null,
-              responseStatus: 900,
-              egressBytes: 0,
-              cacheMissEgressBytes: 0,
-              requestCountryCode,
-              timestamp: requestTimestamp,
-              dataSetId: candidate.dataSetId,
-              botName,
-            })
-          }
-        })(),
-      )
-
-      // Return immediately, proxying the transformed response. The headers
-      // already carry the CAR-to-raw adjustments from processIpfsResponse.
-      const response = new Response(returnedStream, {
-        status: originResponse.status,
-        statusText: originResponse.statusText,
-        headers: responseHeaders,
-      })
-      setRetrievalResponseHeaders(response, {
+      return {
+        response,
+        cacheMiss,
         dataSetId: candidate.dataSetId,
-        clientCacheTtl: env.CLIENT_CACHE_TTL,
-      })
-
-      return response
+        botName,
+        requestCountryCode,
+        timestamp: requestTimestamp,
+        workerStartedAt,
+        fetchStartedAt,
+        // The client is served the raw bytes. On a cache miss the worker
+        // fetched a (larger) CAR from the service provider, which the cache-miss
+        // quota is charged for; for a passed-through CAR (`?format=car`) the two
+        // are equal. Reaching here means the response streamed successfully (a
+        // converted CAR is validated during conversion), so charge every cache
+        // miss.
+        finalizeCacheMiss: async (egressBytes) => ({
+          cacheMissEgressBytes: originEgressBytes ?? egressBytes,
+          cacheMissResponseValid: cacheMiss ? true : null,
+        }),
+      }
     } catch (error) {
       logRetrievalError(env, ctx, error, {
         requestCountryCode,

--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -57,8 +57,6 @@ export default {
       return handleDnsRootRequest(request, env)
     }
 
-    const workerStartedAt = performance.now()
-
     const { dataSetId, pieceId, ipfsSubpath, ipfsFormat, botName } =
       parseRequest(request, env)
 
@@ -126,7 +124,6 @@ export default {
         cacheMiss,
         dataSetId: candidate.dataSetId,
         botName,
-        workerStartedAt,
         fetchStartedAt,
         // The client is served the raw bytes. On a cache miss the worker
         // fetched a (larger) CAR from the service provider, which the cache-miss

--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -27,8 +27,8 @@ export default {
    * @returns
    */
   async fetch(request, env, ctx, options) {
-    return handleFetchRequest(request, env, ctx, () =>
-      this._fetch(request, env, ctx, options),
+    return handleFetchRequest(request, env, ctx, (context) =>
+      this._fetch(request, env, ctx, options, context),
     )
   },
 
@@ -38,6 +38,7 @@ export default {
    * @param {ExecutionContext} ctx
    * @param {object} options
    * @param {typeof defaultRetrieveIpfsContent} [options.retrieveIpfsContent]
+   * @param {import('@filbeam/retrieval').RequestContext} context
    * @returns {Promise<
    *   Response | import('@filbeam/retrieval').RetrievalOutcome
    * >}
@@ -47,6 +48,7 @@ export default {
     env,
     ctx,
     { retrieveIpfsContent = defaultRetrieveIpfsContent } = {},
+    { requestTimestamp, requestCountryCode },
   ) {
     if (
       URL.parse(request.url)?.hostname === env.DNS_ROOT.slice(1) ||
@@ -55,9 +57,7 @@ export default {
       return handleDnsRootRequest(request, env)
     }
 
-    const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
-    const requestCountryCode = request.headers.get('CF-IPCountry')
 
     const { dataSetId, pieceId, ipfsSubpath, ipfsFormat, botName } =
       parseRequest(request, env)
@@ -126,8 +126,6 @@ export default {
         cacheMiss,
         dataSetId: candidate.dataSetId,
         botName,
-        requestCountryCode,
-        timestamp: requestTimestamp,
         workerStartedAt,
         fetchStartedAt,
         // The client is served the raw bytes. On a cache miss the worker

--- a/ipfs-retriever/lib/retrieval.js
+++ b/ipfs-retriever/lib/retrieval.js
@@ -57,25 +57,6 @@ export async function retrieveIpfsContent(
 }
 
 /**
- * Measures the egress of a request by reading from a readable stream and return
- * the total number of bytes transferred.
- *
- * @param {ReadableStreamDefaultReader<Uint8Array>} reader - The reader for the
- *   readable stream.
- * @returns {Promise<number>} - A promise that resolves to the total number of
- *   bytes transferred.
- */
-export async function measureStreamedEgress(reader) {
-  let total = 0
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    total += value.length
-  }
-  return total
-}
-
-/**
  * @param {string} serviceUrl
  * @param {string} rootCid
  * @param {string} subpath

--- a/ipfs-retriever/test/retriever.test.js
+++ b/ipfs-retriever/test/retriever.test.js
@@ -22,6 +22,23 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+/**
+ * Calls the worker and drains the response body so the back-pressured egress
+ * measurement (which only advances as the client reads) completes before the
+ * test waits on the execution context. Returns a re-readable response with the
+ * same status, headers and bytes. A body-less response is returned unchanged.
+ *
+ * @param {Request} req
+ * @param {Env} env
+ * @param {ExecutionContext} ctx
+ * @param {object} [options]
+ */
+async function fetchAndRead(req, env, ctx, options = {}) {
+  const res = await worker.fetch(req, env, ctx, options)
+  if (!res.body) return res
+  return new Response(await res.arrayBuffer(), res)
+}
+
 const DNS_ROOT = '.ipfs.filbeam.io'
 env.DNS_ROOT = DNS_ROOT
 const botTokens = { secret: 'testbot' }
@@ -81,7 +98,7 @@ describe('retriever.fetch', () => {
   it('redirects to https://filbeam.com when no CID and no wallet address were provided', async () => {
     const ctx = createExecutionContext()
     const req = new Request(`https://${DNS_ROOT.slice(1)}/`)
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(302)
     expect(res.headers.get('Location')).toBe('https://filbeam.com/')
@@ -92,7 +109,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `https://${DNS_ROOT.slice(1)}/${defaultPayerAddress}`,
     )
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(404)
     expect(await res.text()).toContain('Invalid path format')
@@ -105,7 +122,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `https://${DNS_ROOT.slice(1)}/${invalidWallet}/${ipfsRootCid}`,
     )
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(404)
     expect(await res.text()).toContain('Invalid wallet address')
@@ -137,7 +154,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `https://${DNS_ROOT.slice(1)}/${testPayerAddress}/${testIpfsRootCid}`,
     )
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(302)
     const location = res.headers.get('Location')
@@ -170,7 +187,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `https://${DNS_ROOT.slice(1)}/${testPayerAddress.toUpperCase()}/${testIpfsRootCid}`,
     )
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(302)
     const location = res.headers.get('Location')
@@ -204,7 +221,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `https://${DNS_ROOT.slice(1)}/${testPayerAddress}/${testIpfsRootCid}/${subpath}`,
     )
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(302)
     const location = res.headers.get('Location')
@@ -217,7 +234,7 @@ describe('retriever.fetch', () => {
   it('redirects to https://*.filcdn.io/* when old domain was used', async () => {
     const ctx = createExecutionContext()
     const req = new Request(`https://foo.filcdn.io/bar`)
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(301)
     expect(res.headers.get('Location')).toBe(`https://foo.filbeam.io/bar`)
@@ -226,7 +243,7 @@ describe('retriever.fetch', () => {
   it('returns 405 for unsupported request methods', async () => {
     const ctx = createExecutionContext()
     const req = withRequest('1', '1', 'POST')
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(405)
     expect(await res.text()).toBe('Method Not Allowed')
@@ -238,7 +255,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `http://${buildSlug(BigInt(realDataSetId), BigInt(realPieceId)).replace(/^(1-)/, '')}.${DNS_ROOT.slice(1)}`,
     )
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -251,7 +268,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `http://${buildSlug(BigInt(realDataSetId), BigInt(realPieceId))}1.${DNS_ROOT.slice(1)}`,
     )
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -270,7 +287,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -287,7 +304,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -304,7 +321,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -325,7 +342,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -341,7 +358,7 @@ describe('retriever.fetch', () => {
       '804edafec384735102b5e9bd99a0bc57922381bdc8685221f7e30ab865176f13'
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, { retrieveIpfsContent })
+    const res = await fetchAndRead(req, env, ctx, { retrieveIpfsContent })
     await waitOnExecutionContext(ctx)
     expect(res.status).toBe(200)
     // get the sha256 hash of the content
@@ -364,7 +381,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -401,7 +418,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -440,7 +457,7 @@ describe('retriever.fetch', () => {
     }
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -478,7 +495,7 @@ describe('retriever.fetch', () => {
     const req = withRequest(realDataSetId, realPieceId, 'GET', {
       'CF-IPCountry': 'US',
     })
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -509,7 +526,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -547,6 +564,8 @@ describe('retriever.fetch', () => {
         format: 'car',
       },
     )
+    // Not fetchAndRead: the body errors mid-stream, and the source error (not
+    // client consumption) drives the 900. Draining it here would throw.
     const res = await worker.fetch(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
@@ -558,6 +577,8 @@ describe('retriever.fetch', () => {
     )
       .bind(String(realDataSetId))
       .first()
+    // The client never reads, so back-pressure stops the chunk being counted
+    // before the source errors.
     expect(log).toEqual({ response_status: 900, egress_bytes: 0 })
   })
 
@@ -573,7 +594,7 @@ describe('retriever.fetch', () => {
             try {
               const ctx = createExecutionContext()
               const req = withRequest(dataSetId, pieceCid)
-              const res = await worker.fetch(req, env, ctx, {
+              const res = await fetchAndRead(req, env, ctx, {
                 retrieveIpfsContent,
               })
               await waitOnExecutionContext(ctx)
@@ -634,7 +655,7 @@ describe('retriever.fetch', () => {
     const req = withRequest(realDataSetId, realPieceId, 'GET', {
       authorization: `Bearer ${botToken}`,
     })
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -684,7 +705,7 @@ describe('retriever.fetch', () => {
       {},
       { format: null },
     )
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -744,7 +765,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId, 'GET', {}, { format: null })
-    const res = await worker.fetch(
+    const res = await fetchAndRead(
       req,
       { ...env, ENFORCE_EGRESS_QUOTA: true },
       ctx,
@@ -801,7 +822,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId, 'GET', {}, { format: 'car' })
-    const res = await worker.fetch(
+    const res = await fetchAndRead(
       req,
       { ...env, ENFORCE_EGRESS_QUOTA: true },
       ctx,
@@ -873,7 +894,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest('8800', '8800', 'GET', {}, { format: 'car' })
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -924,7 +945,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId, 'GET')
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
 
     assert.strictEqual(res.status, 402)
@@ -961,7 +982,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -988,7 +1009,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId)
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
 
     // Expect an error because no URL was found
@@ -1006,7 +1027,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -1022,7 +1043,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -1053,7 +1074,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -1071,7 +1092,7 @@ describe('retriever.fetch', () => {
     })
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId, 'HEAD')
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -1089,7 +1110,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId)
-    const res = await worker.fetch(req, env, ctx, {
+    const res = await fetchAndRead(req, env, ctx, {
       retrieveIpfsContent: mockRetrieveIpfsContent,
     })
     await waitOnExecutionContext(ctx)
@@ -1131,7 +1152,7 @@ describe('retriever.fetch', () => {
     )
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId)
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
 
     assert.strictEqual(res.status, 403)
@@ -1139,7 +1160,7 @@ describe('retriever.fetch', () => {
   it('does not log to retrieval_logs on method not allowed (405)', async () => {
     const ctx = createExecutionContext()
     const req = withRequest(realDataSetId, realPieceId, 'POST')
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
 
     expect(res.status).toBe(405)
@@ -1177,7 +1198,7 @@ describe('retriever.fetch', () => {
 
     const ctx = createExecutionContext()
     const req = withRequest(dataSetId, pieceId)
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
 
     expect(res.status).toBe(404)
@@ -1197,7 +1218,7 @@ describe('retriever.fetch', () => {
     const req = new Request(
       `http://${buildSlug(BigInt(realDataSetId), BigInt(realPieceId))}1.${DNS_ROOT.slice(1)}`,
     )
-    const res = await worker.fetch(req, env, ctx)
+    const res = await fetchAndRead(req, env, ctx)
     await waitOnExecutionContext(ctx)
 
     expect(res.status).toBe(400)
@@ -1227,7 +1248,7 @@ describe('retriever.fetch', () => {
     )
     const req = new Request(url)
 
-    const res = await worker.fetch(req, env, ctx, { retrieveIpfsContent })
+    const res = await fetchAndRead(req, env, ctx, { retrieveIpfsContent })
     await waitOnExecutionContext(ctx)
 
     expect(res.status).toBe(200)

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -23,8 +23,8 @@ export default {
    * @returns
    */
   async fetch(request, env, ctx, options) {
-    return handleFetchRequest(request, env, ctx, () =>
-      this._fetch(request, env, ctx, options),
+    return handleFetchRequest(request, env, ctx, (context) =>
+      this._fetch(request, env, ctx, options, context),
     )
   },
 
@@ -34,18 +34,23 @@ export default {
    * @param {ExecutionContext} ctx
    * @param {object} options
    * @param {typeof defaultRetrieveFile} [options.retrieveFile]
+   * @param {import('@filbeam/retrieval').RequestContext} context
    * @returns {Promise<
    *   Response | import('@filbeam/retrieval').RetrievalOutcome
    * >}
    */
-  async _fetch(request, env, ctx, { retrieveFile = defaultRetrieveFile } = {}) {
+  async _fetch(
+    request,
+    env,
+    ctx,
+    { retrieveFile = defaultRetrieveFile } = {},
+    { requestTimestamp, requestCountryCode },
+  ) {
     if (URL.parse(request.url)?.pathname === '/') {
       return Response.redirect('https://filbeam.com/', 302)
     }
 
-    const requestTimestamp = new Date().toISOString()
     const workerStartedAt = performance.now()
-    const requestCountryCode = request.headers.get('CF-IPCountry')
 
     const { payerWalletAddress, pieceCid, botName, validateCacheMissResponse } =
       parseRequest(request, env)
@@ -102,8 +107,6 @@ export default {
         cacheMiss: retrievalResult.cacheMiss,
         dataSetId: retrievalCandidate.dataSetId,
         botName,
-        requestCountryCode,
-        timestamp: requestTimestamp,
         workerStartedAt,
         fetchStartedAt,
         // Validate the cache-miss response (a `?validate` request) once it has

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -50,8 +50,6 @@ export default {
       return Response.redirect('https://filbeam.com/', 302)
     }
 
-    const workerStartedAt = performance.now()
-
     const { payerWalletAddress, pieceCid, botName, validateCacheMissResponse } =
       parseRequest(request, env)
 
@@ -107,7 +105,6 @@ export default {
         cacheMiss: retrievalResult.cacheMiss,
         dataSetId: retrievalCandidate.dataSetId,
         botName,
-        workerStartedAt,
         fetchStartedAt,
         // Validate the cache-miss response (a `?validate` request) once it has
         // streamed, and drop the cache entry when it fails validation.

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -1,13 +1,9 @@
 import {
   httpAssert,
-  setRetrievalResponseHeaders,
   assertCidNotDenied,
-  logRetrievalResult,
-  recordRetrieval,
   logRetrievalError,
   handleFetchRequest,
   selectRetrievalCandidate,
-  handleEmptyBodyResponse,
 } from '@filbeam/retrieval'
 
 import { parseRequest } from '../lib/request.js'
@@ -27,7 +23,7 @@ export default {
    * @returns
    */
   async fetch(request, env, ctx, options) {
-    return handleFetchRequest(request, () =>
+    return handleFetchRequest(request, env, ctx, () =>
       this._fetch(request, env, ctx, options),
     )
   },
@@ -38,7 +34,9 @@ export default {
    * @param {ExecutionContext} ctx
    * @param {object} options
    * @param {typeof defaultRetrieveFile} [options.retrieveFile]
-   * @returns
+   * @returns {Promise<
+   *   Response | import('@filbeam/retrieval').RetrievalOutcome
+   * >}
    */
   async _fetch(request, env, ctx, { retrieveFile = defaultRetrieveFile } = {}) {
     if (URL.parse(request.url)?.pathname === '/') {
@@ -99,141 +97,30 @@ export default {
         'should never happen',
       )
 
-      if (!retrievalResult.response.body) {
-        return handleEmptyBodyResponse(env, ctx, {
-          response: retrievalResult.response,
-          cacheMiss: retrievalResult.cacheMiss,
-          dataSetId: retrievalCandidate.dataSetId,
-          requestCountryCode,
-          timestamp: requestTimestamp,
-          botName,
-        })
-      }
-
-      // Stream, count bytes and validate (a cache miss)
-      let egressBytes = 0
-      /** @type {number | null} */
-      let firstByteAt = null
-
-      /** @type {number | null} */
-      let minChunkSize = null
-      /** @type {number | null} */
-      let maxChunkSize = null
-      let bytesReceived = 0
-
-      const logStreamStats = () => {
-        console.log(
-          'Stream stats ' +
-            `minChunkSize=${minChunkSize} ` +
-            `maxChunkSize=${maxChunkSize} ` +
-            `bytesReceived=${bytesReceived} ` +
-            `url=${request.url} ` +
-            `cf-ray=${request.headers.get('cf-ray')}`,
-        )
-        minChunkSize = null
-        maxChunkSize = null
-        bytesReceived = 0
-      }
-
-      const iv = setInterval(logStreamStats, 10_000)
-
-      const measureStream = new TransformStream({
-        transform(chunk, controller) {
-          if (firstByteAt === null) {
-            console.log('First byte received')
-            firstByteAt = performance.now()
-          }
-          egressBytes += chunk.length
-          bytesReceived += chunk.length
-          if (minChunkSize === null || chunk.length < minChunkSize) {
-            minChunkSize = chunk.length
-          }
-          if (maxChunkSize === null || chunk.length > maxChunkSize) {
-            maxChunkSize = chunk.length
-          }
-          controller.enqueue(chunk)
-        },
-        flush() {
-          logStreamStats()
-          clearInterval(iv)
-        },
-      })
-
-      const returnedStream = new TransformStream()
-
-      ctx.waitUntil(
-        (async () => {
-          try {
-            httpAssert(
-              retrievalResult.response.body,
-              500,
-              'Should never happen',
-            )
-            await Promise.all([
-              retrievalResult.response.body.pipeTo(measureStream.writable),
-              measureStream.readable.pipeTo(returnedStream.writable),
-            ])
-            console.log('Response finished')
-
-            const cacheMissResponseValid =
-              typeof retrievalResult.validate === 'function'
-                ? retrievalResult.validate()
-                : null
-            httpAssert(firstByteAt, 500, 'Should never happen')
-            const lastByteFetchedAt = performance.now()
-
-            if (cacheMissResponseValid === false) {
-              await caches.default.delete(
-                getRetrievalUrl(retrievalCandidate.serviceUrl, pieceCid),
-              )
-            }
-
-            await recordRetrieval(env, {
-              cacheMiss: retrievalResult.cacheMiss,
-              cacheMissResponseValid,
-              responseStatus: retrievalResult.response.status,
-              egressBytes,
-              requestCountryCode,
-              timestamp: requestTimestamp,
-              performanceStats: {
-                fetchTtfb: firstByteAt - fetchStartedAt,
-                fetchTtlb: lastByteFetchedAt - fetchStartedAt,
-                workerTtfb: firstByteAt - workerStartedAt,
-              },
-              dataSetId: retrievalCandidate.dataSetId,
-              botName,
-              enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
-            })
-          } catch (err) {
-            console.error('Error in server stream:', err)
-            logStreamStats()
-            clearInterval(iv)
-
-            await logRetrievalResult(env, {
-              cacheMiss: retrievalResult.cacheMiss,
-              cacheMissResponseValid: null,
-              responseStatus: 900,
-              egressBytes,
-              requestCountryCode,
-              timestamp: requestTimestamp,
-              dataSetId: retrievalCandidate.dataSetId,
-              botName,
-            })
-          }
-        })(),
-      )
-
-      // Return immediately, proxying the transformed response
-      const response = new Response(returnedStream.readable, {
-        status: retrievalResult.response.status,
-        statusText: retrievalResult.response.statusText,
-        headers: retrievalResult.response.headers,
-      })
-      setRetrievalResponseHeaders(response, {
+      return {
+        response: retrievalResult.response,
+        cacheMiss: retrievalResult.cacheMiss,
         dataSetId: retrievalCandidate.dataSetId,
-        clientCacheTtl: env.CLIENT_CACHE_TTL,
-      })
-      return response
+        botName,
+        requestCountryCode,
+        timestamp: requestTimestamp,
+        workerStartedAt,
+        fetchStartedAt,
+        // Validate the cache-miss response (a `?validate` request) once it has
+        // streamed, and drop the cache entry when it fails validation.
+        finalizeCacheMiss: async () => {
+          const cacheMissResponseValid =
+            typeof retrievalResult.validate === 'function'
+              ? retrievalResult.validate()
+              : null
+          if (cacheMissResponseValid === false) {
+            await caches.default.delete(
+              getRetrievalUrl(retrievalCandidate.serviceUrl, pieceCid),
+            )
+          }
+          return { cacheMissResponseValid }
+        },
+      }
     } catch (error) {
       logRetrievalError(env, ctx, error, {
         requestCountryCode,

--- a/retrieval/lib/fetch-handler.js
+++ b/retrieval/lib/fetch-handler.js
@@ -17,8 +17,6 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  * @property {boolean} cacheMiss
  * @property {string} dataSetId
  * @property {string | undefined} botName
- * @property {string | null} requestCountryCode
- * @property {string} timestamp
  * @property {number} workerStartedAt
  * @property {number} fetchStartedAt
  * @property {(egressBytes: number) => Promise<{
@@ -28,6 +26,14 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  *   - Computes the worker-specific cache-miss accounting once the bytes served to
  *       the client are known. Runs after the response has streamed, before the
  *       retrieval is logged.
+ */
+
+/**
+ * Per-request telemetry shared by the success and error logging paths.
+ *
+ * @typedef {object} RequestContext
+ * @property {string} requestTimestamp - ISO timestamp of the request.
+ * @property {string | null} requestCountryCode - The request's `CF-IPCountry`.
  */
 
 /**
@@ -48,13 +54,22 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  *   ENFORCE_EGRESS_QUOTA: boolean
  * }} env
  * @param {ExecutionContext} ctx
- * @param {() => Promise<Response | RetrievalOutcome>} run
+ * @param {(context: RequestContext) => Promise<Response | RetrievalOutcome>} run
+ *   - Invokes the worker handler with the per-request telemetry context.
+ *
  * @returns {Promise<Response>}
  */
 export async function handleFetchRequest(request, env, ctx, run) {
   request.signal.addEventListener('abort', () => {
     console.log('The request was aborted!', { url: request.url })
   })
+
+  /** @type {RequestContext} */
+  const context = {
+    requestTimestamp: new Date().toISOString(),
+    requestCountryCode: request.headers.get('CF-IPCountry'),
+  }
+
   try {
     httpAssert(
       ['GET', 'HEAD'].includes(request.method),
@@ -64,10 +79,10 @@ export async function handleFetchRequest(request, env, ctx, run) {
     const legacyRedirect = redirectLegacyDomain(request)
     if (legacyRedirect) return legacyRedirect
 
-    const result = await run()
+    const result = await run(context)
     if (result instanceof Response) return result
 
-    return serveRetrievalOutcome(env, ctx, result)
+    return serveRetrievalOutcome(env, ctx, result, context)
   } catch (error) {
     return handleError(error)
   }
@@ -84,16 +99,20 @@ export async function handleFetchRequest(request, env, ctx, run) {
  * }} env
  * @param {ExecutionContext} ctx
  * @param {RetrievalOutcome} result
+ * @param {RequestContext} context
  * @returns {Response}
  */
-function serveRetrievalOutcome(env, ctx, result) {
+function serveRetrievalOutcome(
+  env,
+  ctx,
+  result,
+  { requestCountryCode, requestTimestamp: timestamp },
+) {
   const {
     response,
     cacheMiss,
     dataSetId,
     botName,
-    requestCountryCode,
-    timestamp,
     workerStartedAt,
     fetchStartedAt,
     finalizeCacheMiss,

--- a/retrieval/lib/fetch-handler.js
+++ b/retrieval/lib/fetch-handler.js
@@ -1,18 +1,57 @@
 import { handleError } from './http-error.js'
 import { httpAssert } from './http-assert.js'
 import { redirectLegacyDomain } from './redirect.js'
+import { handleEmptyBodyResponse } from './empty-body-response.js'
+import { setRetrievalResponseHeaders } from './response-headers.js'
+import { recordRetrieval, logRetrievalResult } from './stats.js'
 
 /**
- * Runs a worker's fetch implementation with the shared request lifecycle: log
- * when the request is aborted, reject non-GET/HEAD methods with a 405, redirect
+ * The successful retrieval outcome a worker hands back to
+ * {@link handleFetchRequest}: the response to serve plus the metadata needed to
+ * measure egress and log the retrieval.
+ *
+ * @typedef {object} RetrievalOutcome
+ * @property {Response} response - The response to serve. Its body is streamed
+ *   to the client and measured; a `null` body is logged as a zero-egress result
+ *   and returned unchanged.
+ * @property {boolean} cacheMiss
+ * @property {string} dataSetId
+ * @property {string | undefined} botName
+ * @property {string | null} requestCountryCode
+ * @property {string} timestamp
+ * @property {number} workerStartedAt
+ * @property {number} fetchStartedAt
+ * @property {(egressBytes: number) => Promise<{
+ *   cacheMissEgressBytes?: number
+ *   cacheMissResponseValid: boolean | null
+ * }>} finalizeCacheMiss
+ *   - Computes the worker-specific cache-miss accounting once the bytes served to
+ *       the client are known. Runs after the response has streamed, before the
+ *       retrieval is logged.
+ */
+
+/**
+ * Runs a worker's retrieval handler with the shared request lifecycle: log when
+ * the request is aborted, reject non-GET/HEAD methods with a `405`, redirect
  * legacy `*.filcdn.io` requests to `*.filbeam.io`, and turn thrown errors into
  * HTTP responses via {@link handleError}.
  *
+ * The handler returns either a plain {@link Response} (redirects, the
+ * no-service-provider response, ...), which is served as-is, or a
+ * {@link RetrievalOutcome}, whose body is streamed to the client while its
+ * egress is measured and the retrieval is logged.
+ *
  * @param {Request} request
- * @param {() => Promise<Response>} run - Invokes the worker's request handler.
+ * @param {{
+ *   DB: D1Database
+ *   CLIENT_CACHE_TTL: number
+ *   ENFORCE_EGRESS_QUOTA: boolean
+ * }} env
+ * @param {ExecutionContext} ctx
+ * @param {() => Promise<Response | RetrievalOutcome>} run
  * @returns {Promise<Response>}
  */
-export async function handleFetchRequest(request, run) {
+export async function handleFetchRequest(request, env, ctx, run) {
   request.signal.addEventListener('abort', () => {
     console.log('The request was aborted!', { url: request.url })
   })
@@ -24,8 +63,120 @@ export async function handleFetchRequest(request, run) {
     )
     const legacyRedirect = redirectLegacyDomain(request)
     if (legacyRedirect) return legacyRedirect
-    return await run()
+
+    const result = await run()
+    if (result instanceof Response) return result
+
+    return serveRetrievalOutcome(env, ctx, result)
   } catch (error) {
     return handleError(error)
   }
+}
+
+/**
+ * Streams a retrieval response to the client while measuring egress and logging
+ * the result on the execution context. Returns the response immediately.
+ *
+ * @param {{
+ *   DB: D1Database
+ *   CLIENT_CACHE_TTL: number
+ *   ENFORCE_EGRESS_QUOTA: boolean
+ * }} env
+ * @param {ExecutionContext} ctx
+ * @param {RetrievalOutcome} result
+ * @returns {Response}
+ */
+function serveRetrievalOutcome(env, ctx, result) {
+  const {
+    response,
+    cacheMiss,
+    dataSetId,
+    botName,
+    requestCountryCode,
+    timestamp,
+    workerStartedAt,
+    fetchStartedAt,
+    finalizeCacheMiss,
+  } = result
+
+  // No readable body (e.g. a HEAD request or an error status): nothing to
+  // stream or measure.
+  if (!response.body) {
+    return handleEmptyBodyResponse(env, ctx, {
+      response,
+      cacheMiss,
+      dataSetId,
+      requestCountryCode,
+      timestamp,
+      botName,
+    })
+  }
+
+  // Tee the body: one branch is returned to the client, the other is drained
+  // here to measure egress independently of how fast the client reads.
+  const [returnedStream, egressStream] = response.body.tee()
+  const egressReader = egressStream.getReader()
+
+  ctx.waitUntil(
+    (async () => {
+      let egressBytes = 0
+      /** @type {number | null} */
+      let firstByteAt = null
+      try {
+        while (true) {
+          const { done, value } = await egressReader.read()
+          if (done) break
+          if (firstByteAt === null) firstByteAt = performance.now()
+          egressBytes += value.length
+        }
+        const lastByteFetchedAt = performance.now()
+        const startedAt = firstByteAt ?? lastByteFetchedAt
+
+        const { cacheMissEgressBytes, cacheMissResponseValid } =
+          await finalizeCacheMiss(egressBytes)
+
+        await recordRetrieval(env, {
+          cacheMiss,
+          cacheMissResponseValid,
+          cacheMissEgressBytes,
+          responseStatus: response.status,
+          egressBytes,
+          requestCountryCode,
+          timestamp,
+          performanceStats: {
+            fetchTtfb: startedAt - fetchStartedAt,
+            fetchTtlb: lastByteFetchedAt - fetchStartedAt,
+            workerTtfb: startedAt - workerStartedAt,
+          },
+          dataSetId,
+          botName,
+          enforceEgressQuota: env.ENFORCE_EGRESS_QUOTA,
+        })
+      } catch (err) {
+        console.error('Error in server stream:', err)
+
+        await logRetrievalResult(env, {
+          cacheMiss,
+          cacheMissResponseValid: null,
+          responseStatus: 900,
+          egressBytes,
+          requestCountryCode,
+          timestamp,
+          dataSetId,
+          botName,
+        })
+      }
+    })(),
+  )
+
+  const proxied = new Response(returnedStream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+  setRetrievalResponseHeaders(proxied, {
+    dataSetId,
+    clientCacheTtl: env.CLIENT_CACHE_TTL,
+  })
+  return proxied
 }

--- a/retrieval/lib/fetch-handler.js
+++ b/retrieval/lib/fetch-handler.js
@@ -112,23 +112,30 @@ function serveRetrievalOutcome(env, ctx, result) {
     })
   }
 
-  // Tee the body: one branch is returned to the client, the other is drained
-  // here to measure egress independently of how fast the client reads.
-  const [returnedStream, egressStream] = response.body.tee()
-  const egressReader = egressStream.getReader()
+  // Measure egress by piping the body through a counting transform on its way
+  // to the client. This preserves backpressure: the origin is pulled only as
+  // fast as the client reads, so a slow client cannot make the worker buffer
+  // the whole response in memory.
+  const responseBody = response.body
+  let egressBytes = 0
+  /** @type {number | null} */
+  let firstByteAt = null
+  const measureStream = new TransformStream({
+    transform(chunk, controller) {
+      if (firstByteAt === null) firstByteAt = performance.now()
+      egressBytes += chunk.length
+      controller.enqueue(chunk)
+    },
+  })
+  const returnedStream = new TransformStream()
 
   ctx.waitUntil(
     (async () => {
-      let egressBytes = 0
-      /** @type {number | null} */
-      let firstByteAt = null
       try {
-        while (true) {
-          const { done, value } = await egressReader.read()
-          if (done) break
-          if (firstByteAt === null) firstByteAt = performance.now()
-          egressBytes += value.length
-        }
+        await Promise.all([
+          responseBody.pipeTo(measureStream.writable),
+          measureStream.readable.pipeTo(returnedStream.writable),
+        ])
         const lastByteFetchedAt = performance.now()
         const startedAt = firstByteAt ?? lastByteFetchedAt
 
@@ -169,7 +176,7 @@ function serveRetrievalOutcome(env, ctx, result) {
     })(),
   )
 
-  const proxied = new Response(returnedStream, {
+  const proxied = new Response(returnedStream.readable, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,

--- a/retrieval/lib/fetch-handler.js
+++ b/retrieval/lib/fetch-handler.js
@@ -17,7 +17,6 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  * @property {boolean} cacheMiss
  * @property {string} dataSetId
  * @property {string | undefined} botName
- * @property {number} workerStartedAt
  * @property {number} fetchStartedAt
  * @property {(egressBytes: number) => Promise<{
  *   cacheMissEgressBytes?: number
@@ -34,6 +33,8 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  * @typedef {object} RequestContext
  * @property {string} requestTimestamp - ISO timestamp of the request.
  * @property {string | null} requestCountryCode - The request's `CF-IPCountry`.
+ * @property {number} workerStartedAt - `performance.now()` when the worker
+ *   started handling the request.
  */
 
 /**
@@ -68,6 +69,7 @@ export async function handleFetchRequest(request, env, ctx, run) {
   const context = {
     requestTimestamp: new Date().toISOString(),
     requestCountryCode: request.headers.get('CF-IPCountry'),
+    workerStartedAt: performance.now(),
   }
 
   try {
@@ -106,14 +108,13 @@ function serveRetrievalOutcome(
   env,
   ctx,
   result,
-  { requestCountryCode, requestTimestamp: timestamp },
+  { requestCountryCode, requestTimestamp: timestamp, workerStartedAt },
 ) {
   const {
     response,
     cacheMiss,
     dataSetId,
     botName,
-    workerStartedAt,
     fetchStartedAt,
     finalizeCacheMiss,
   } = result

--- a/retrieval/test/fetch-handler.test.js
+++ b/retrieval/test/fetch-handler.test.js
@@ -1,10 +1,39 @@
 import { describe, it, expect } from 'vitest'
 import { handleFetchRequest } from '../lib/fetch-handler.js'
+import {
+  env,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from 'cloudflare:test'
+
+const testEnv = {
+  ...env,
+  CLIENT_CACHE_TTL: 31536000,
+  ENFORCE_EGRESS_QUOTA: false,
+}
+
+function retrievalResult(overrides = {}) {
+  return {
+    response: new Response('hello world', { status: 200 }),
+    cacheMiss: true,
+    dataSetId: 'fh-test',
+    botName: undefined,
+    requestCountryCode: 'US',
+    timestamp: new Date().toISOString(),
+    workerStartedAt: performance.now(),
+    fetchStartedAt: performance.now(),
+    finalizeCacheMiss: async () => ({ cacheMissResponseValid: true }),
+    ...overrides,
+  }
+}
 
 describe('handleFetchRequest', () => {
-  it('returns the handler response unchanged', async () => {
+  it('returns a plain handler response unchanged', async () => {
+    const ctx = createExecutionContext()
     const res = await handleFetchRequest(
       new Request('https://example.com/'),
+      testEnv,
+      ctx,
       async () => new Response('ok', { status: 200 }),
     )
 
@@ -13,9 +42,12 @@ describe('handleFetchRequest', () => {
   })
 
   it('rejects non-GET/HEAD methods with 405 without running the handler', async () => {
+    const ctx = createExecutionContext()
     let ran = false
     const res = await handleFetchRequest(
       new Request('https://example.com/', { method: 'POST' }),
+      testEnv,
+      ctx,
       async () => {
         ran = true
         return new Response('ok')
@@ -28,8 +60,11 @@ describe('handleFetchRequest', () => {
   })
 
   it('allows HEAD requests', async () => {
+    const ctx = createExecutionContext()
     const res = await handleFetchRequest(
       new Request('https://example.com/', { method: 'HEAD' }),
+      testEnv,
+      ctx,
       async () => new Response('ok', { status: 200 }),
     )
 
@@ -37,9 +72,12 @@ describe('handleFetchRequest', () => {
   })
 
   it('redirects legacy *.filcdn.io requests before running the handler', async () => {
+    const ctx = createExecutionContext()
     let ran = false
     const res = await handleFetchRequest(
       new Request('https://0xabc.filcdn.io/baga123'),
+      testEnv,
+      ctx,
       async () => {
         ran = true
         return new Response('ok')
@@ -52,8 +90,11 @@ describe('handleFetchRequest', () => {
   })
 
   it('turns a thrown error into a response via handleError', async () => {
+    const ctx = createExecutionContext()
     const res = await handleFetchRequest(
       new Request('https://example.com/'),
+      testEnv,
+      ctx,
       async () => {
         throw Object.assign(new Error('Bad Request'), { status: 400 })
       },
@@ -64,8 +105,11 @@ describe('handleFetchRequest', () => {
   })
 
   it('hides the message for server errors', async () => {
+    const ctx = createExecutionContext()
     const res = await handleFetchRequest(
       new Request('https://example.com/'),
+      testEnv,
+      ctx,
       async () => {
         throw new Error('boom')
       },
@@ -73,5 +117,98 @@ describe('handleFetchRequest', () => {
 
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
+  })
+
+  it('streams a retrieval result, measuring egress and logging it', async () => {
+    const ctx = createExecutionContext()
+    const dataSetId = 'fh-stream'
+    let finalizedEgress
+    const res = await handleFetchRequest(
+      new Request('https://example.com/'),
+      testEnv,
+      ctx,
+      async () =>
+        retrievalResult({
+          dataSetId,
+          finalizeCacheMiss: async (egressBytes) => {
+            finalizedEgress = egressBytes
+            return { cacheMissResponseValid: true }
+          },
+        }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Data-Set-ID')).toBe(dataSetId)
+    expect(await res.text()).toBe('hello world')
+    await waitOnExecutionContext(ctx)
+
+    expect(finalizedEgress).toBe('hello world'.length)
+    const log = await env.DB.prepare(
+      `SELECT response_status, egress_bytes, cache_miss
+       FROM retrieval_logs WHERE data_set_id = ?`,
+    )
+      .bind(dataSetId)
+      .first()
+    expect(log).toEqual({
+      response_status: 200,
+      egress_bytes: 'hello world'.length,
+      cache_miss: 1,
+    })
+  })
+
+  it('logs a zero-egress result for a response without a body', async () => {
+    const ctx = createExecutionContext()
+    const dataSetId = 'fh-empty'
+    const res = await handleFetchRequest(
+      new Request('https://example.com/'),
+      testEnv,
+      ctx,
+      async () =>
+        retrievalResult({
+          dataSetId,
+          response: new Response(null, { status: 404 }),
+        }),
+    )
+    await waitOnExecutionContext(ctx)
+
+    expect(res.status).toBe(404)
+    expect(res.body).toBeNull()
+    expect(res.headers.get('X-Data-Set-ID')).toBe(dataSetId)
+    const log = await env.DB.prepare(
+      'SELECT response_status, egress_bytes FROM retrieval_logs WHERE data_set_id = ?',
+    )
+      .bind(dataSetId)
+      .first()
+    expect(log).toEqual({ response_status: 404, egress_bytes: 0 })
+  })
+
+  it('logs a 900 result when streaming the body errors', async () => {
+    const ctx = createExecutionContext()
+    const dataSetId = 'fh-stream-error'
+    const erroringBody = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]))
+        controller.error(new Error('stream boom'))
+      },
+    })
+    const res = await handleFetchRequest(
+      new Request('https://example.com/'),
+      testEnv,
+      ctx,
+      async () =>
+        retrievalResult({
+          dataSetId,
+          response: new Response(erroringBody, { status: 200 }),
+        }),
+    )
+    expect(res.status).toBe(200)
+    await waitOnExecutionContext(ctx)
+
+    const log = await env.DB.prepare(
+      'SELECT response_status FROM retrieval_logs WHERE data_set_id = ? AND response_status = 900',
+    )
+      .bind(dataSetId)
+      .first()
+    expect(log).toEqual({ response_status: 900 })
   })
 })

--- a/retrieval/test/fetch-handler.test.js
+++ b/retrieval/test/fetch-handler.test.js
@@ -18,7 +18,6 @@ function retrievalResult(overrides = {}) {
     cacheMiss: true,
     dataSetId: 'fh-test',
     botName: undefined,
-    workerStartedAt: performance.now(),
     fetchStartedAt: performance.now(),
     finalizeCacheMiss: async () => ({ cacheMissResponseValid: true }),
     ...overrides,

--- a/retrieval/test/fetch-handler.test.js
+++ b/retrieval/test/fetch-handler.test.js
@@ -18,8 +18,6 @@ function retrievalResult(overrides = {}) {
     cacheMiss: true,
     dataSetId: 'fh-test',
     botName: undefined,
-    requestCountryCode: 'US',
-    timestamp: new Date().toISOString(),
     workerStartedAt: performance.now(),
     fetchStartedAt: performance.now(),
     finalizeCacheMiss: async () => ({ cacheMissResponseValid: true }),
@@ -124,7 +122,9 @@ describe('handleFetchRequest', () => {
     const dataSetId = 'fh-stream'
     let finalizedEgress
     const res = await handleFetchRequest(
-      new Request('https://example.com/'),
+      new Request('https://example.com/', {
+        headers: { 'CF-IPCountry': 'US' },
+      }),
       testEnv,
       ctx,
       async () =>
@@ -144,15 +144,17 @@ describe('handleFetchRequest', () => {
 
     expect(finalizedEgress).toBe('hello world'.length)
     const log = await env.DB.prepare(
-      `SELECT response_status, egress_bytes, cache_miss
+      `SELECT response_status, egress_bytes, cache_miss, request_country_code
        FROM retrieval_logs WHERE data_set_id = ?`,
     )
       .bind(dataSetId)
       .first()
+    // request_country_code is sourced by handleFetchRequest from the request.
     expect(log).toEqual({
       response_status: 200,
       egress_bytes: 'hello world'.length,
       cache_miss: 1,
+      request_country_code: 'US',
     })
   })
 


### PR DESCRIPTION
Each worker's `_fetch` ran the full response lifecycle itself: stream the body, measure egress, handle an empty body, and record the retrieval. This moves that shared work into `handleFetchRequest`, leaving `_fetch` to return a description of what to serve.

## Strategy

`_fetch` now returns either a plain `Response` (the `/` and DNS-root redirects, the no-service-provider `502`) or a `RetrievalOutcome` descriptor:

```
{ response, cacheMiss, dataSetId, botName, requestCountryCode,
  timestamp, workerStartedAt, fetchStartedAt, finalizeCacheMiss }
```

`handleFetchRequest` (now `(request, env, ctx, run)`) serves a plain `Response` as-is, and for a `RetrievalOutcome`:
- returns the response unchanged when it has no body, logging a zero-egress result (the former `handleEmptyBodyResponse` path);
- otherwise pipes the body through a counting transform on its way to the client, then records the retrieval.

The cache-miss accounting that differs per worker stays in each worker behind `finalizeCacheMiss(egressBytes)`:
- **ipfs** returns the CAR size (`originEgressBytes ?? egressBytes`) and marks the cache miss valid.
- **piece** validates the streamed PieceCID (a `?validate` request) and evicts the cache entry when validation fails.

## Egress measurement is back-pressured

Egress is measured by piping the body through a `TransformStream` on the way to the client, so the origin is pulled only as fast as the client reads. A slow client cannot make the worker buffer the whole response in memory. The retrieval is recorded once the client has consumed the body; a client that disconnects mid-stream produces a `900` log (the pipe errors), as before.

This is the same back-pressured approach piece already used; the ipfs worker previously teed the body and eagerly drained one branch, which buffers the whole response for a slow client.

## Behavioral notes

- ipfs no longer eagerly drains, so it no longer buffers the response for slow clients.
- piece's per-chunk debug logging (`First byte received`, periodic `Stream stats`) is dropped.
- `measureStreamedEgress` is removed from ipfs (the measurement now lives in `handleFetchRequest`).
- ipfs tests drive the body to completion via a `fetchAndRead` helper, since the back-pressured measurement only completes once the body is read.