### PR TITLE
Move retrieval error logging into handleFetchRequest

### DIFF
--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -2,7 +2,6 @@ import {
   isValidEthereumAddress,
   httpAssert,
   assertCidNotDenied,
-  logRetrievalError,
   handleFetchRequest,
   selectRetrievalCandidate,
 } from '@filbeam/retrieval'
@@ -39,16 +38,14 @@ export default {
    * @param {object} options
    * @param {typeof defaultRetrieveIpfsContent} [options.retrieveIpfsContent]
    * @param {import('@filbeam/retrieval').RequestContext} context
-   * @returns {Promise<
-   *   Response | import('@filbeam/retrieval').RetrievalOutcome
-   * >}
+   * @returns {Promise<Response | import('@filbeam/retrieval').Retrieve>}
    */
   async _fetch(
     request,
     env,
     ctx,
     { retrieveIpfsContent = defaultRetrieveIpfsContent } = {},
-    { requestTimestamp, requestCountryCode },
+    context,
   ) {
     if (
       URL.parse(request.url)?.hostname === env.DNS_ROOT.slice(1) ||
@@ -59,8 +56,9 @@ export default {
 
     const { dataSetId, pieceId, ipfsSubpath, ipfsFormat, botName } =
       parseRequest(request, env)
+    context.botName = botName
 
-    try {
+    return async () => {
       // Timestamp to measure file retrieval performance (from cache and from SP)
       const fetchStartedAt = performance.now()
 
@@ -90,7 +88,13 @@ export default {
             env.ORIGIN_CACHE_TTL,
             { signal: request.signal },
           ),
-        { env, ctx, requestCountryCode, timestamp: requestTimestamp, botName },
+        {
+          env,
+          ctx,
+          requestCountryCode: context.requestCountryCode,
+          timestamp: context.requestTimestamp,
+          botName,
+        },
       )
       if (failureResponse) return failureResponse
       httpAssert(candidate && retrievalResult, 500, 'should never happen')
@@ -123,7 +127,6 @@ export default {
         response,
         cacheMiss,
         dataSetId: candidate.dataSetId,
-        botName,
         fetchStartedAt,
         // The client is served the raw bytes. On a cache miss the worker
         // fetched a (larger) CAR from the service provider, which the cache-miss
@@ -136,14 +139,6 @@ export default {
           cacheMissResponseValid: cacheMiss ? true : null,
         }),
       }
-    } catch (error) {
-      logRetrievalError(env, ctx, error, {
-        requestCountryCode,
-        timestamp: requestTimestamp,
-        botName,
-      })
-
-      throw error
     }
   },
 }

--- a/ipfs-retriever/bin/ipfs-retriever.js
+++ b/ipfs-retriever/bin/ipfs-retriever.js
@@ -54,9 +54,10 @@ export default {
       return handleDnsRootRequest(request, env)
     }
 
-    const { dataSetId, pieceId, ipfsSubpath, ipfsFormat, botName } =
-      parseRequest(request, env)
-    context.botName = botName
+    const { dataSetId, pieceId, ipfsSubpath, ipfsFormat } = parseRequest(
+      request,
+      env,
+    )
 
     return async () => {
       // Timestamp to measure file retrieval performance (from cache and from SP)
@@ -93,7 +94,7 @@ export default {
           ctx,
           requestCountryCode: context.requestCountryCode,
           timestamp: context.requestTimestamp,
-          botName,
+          botName: context.botName,
         },
       )
       if (failureResponse) return failureResponse

--- a/ipfs-retriever/lib/request.js
+++ b/ipfs-retriever/lib/request.js
@@ -1,4 +1,4 @@
-import { httpAssert, checkBotAuthorization } from '@filbeam/retrieval'
+import { httpAssert } from '@filbeam/retrieval'
 import { base32ToBigInt } from './bigint-util.js'
 
 /**
@@ -7,16 +7,14 @@ import { base32ToBigInt } from './bigint-util.js'
  * @param {Request} request
  * @param {object} options
  * @param {string} options.DNS_ROOT
- * @param {string} options.BOT_TOKENS
  * @returns {{
  *   dataSetId: string
  *   pieceId: string
  *   ipfsSubpath: string
  *   ipfsFormat: string | null
- *   botName?: string
  * }}
  */
-export function parseRequest(request, { DNS_ROOT, BOT_TOKENS }) {
+export function parseRequest(request, { DNS_ROOT }) {
   const url = new URL(request.url)
   console.log('retrieval request', { DNS_ROOT, url })
 
@@ -75,7 +73,5 @@ export function parseRequest(request, { DNS_ROOT, BOT_TOKENS }) {
   const ipfsSubpath = url.pathname || '/'
   const ipfsFormat = url.searchParams.get('format')
 
-  const botName = checkBotAuthorization(request, { BOT_TOKENS })
-
-  return { dataSetId, pieceId, ipfsSubpath, ipfsFormat, botName }
+  return { dataSetId, pieceId, ipfsSubpath, ipfsFormat }
 }

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -1,7 +1,6 @@
 import {
   httpAssert,
   assertCidNotDenied,
-  logRetrievalError,
   handleFetchRequest,
   selectRetrievalCandidate,
 } from '@filbeam/retrieval'
@@ -35,16 +34,14 @@ export default {
    * @param {object} options
    * @param {typeof defaultRetrieveFile} [options.retrieveFile]
    * @param {import('@filbeam/retrieval').RequestContext} context
-   * @returns {Promise<
-   *   Response | import('@filbeam/retrieval').RetrievalOutcome
-   * >}
+   * @returns {Promise<Response | import('@filbeam/retrieval').Retrieve>}
    */
   async _fetch(
     request,
     env,
     ctx,
     { retrieveFile = defaultRetrieveFile } = {},
-    { requestTimestamp, requestCountryCode },
+    context,
   ) {
     if (URL.parse(request.url)?.pathname === '/') {
       return Response.redirect('https://filbeam.com/', 302)
@@ -52,8 +49,9 @@ export default {
 
     const { payerWalletAddress, pieceCid, botName, validateCacheMissResponse } =
       parseRequest(request, env)
+    context.botName = botName
 
-    try {
+    return async () => {
       // Timestamp to measure file retrieval performance (from cache and from SP)
       const fetchStartedAt = performance.now()
 
@@ -91,7 +89,13 @@ export default {
               addCacheMissResponseValidation: validateCacheMissResponse,
             },
           ),
-        { env, ctx, requestCountryCode, timestamp: requestTimestamp, botName },
+        {
+          env,
+          ctx,
+          requestCountryCode: context.requestCountryCode,
+          timestamp: context.requestTimestamp,
+          botName,
+        },
       )
       if (failureResponse) return failureResponse
       httpAssert(
@@ -104,7 +108,6 @@ export default {
         response: retrievalResult.response,
         cacheMiss: retrievalResult.cacheMiss,
         dataSetId: retrievalCandidate.dataSetId,
-        botName,
         fetchStartedAt,
         // Validate the cache-miss response (a `?validate` request) once it has
         // streamed, and drop the cache entry when it fails validation.
@@ -121,14 +124,6 @@ export default {
           return { cacheMissResponseValid }
         },
       }
-    } catch (error) {
-      logRetrievalError(env, ctx, error, {
-        requestCountryCode,
-        timestamp: requestTimestamp,
-        botName,
-      })
-
-      throw error
     }
   },
 }

--- a/piece-retriever/bin/piece-retriever.js
+++ b/piece-retriever/bin/piece-retriever.js
@@ -47,9 +47,8 @@ export default {
       return Response.redirect('https://filbeam.com/', 302)
     }
 
-    const { payerWalletAddress, pieceCid, botName, validateCacheMissResponse } =
+    const { payerWalletAddress, pieceCid, validateCacheMissResponse } =
       parseRequest(request, env)
-    context.botName = botName
 
     return async () => {
       // Timestamp to measure file retrieval performance (from cache and from SP)
@@ -94,7 +93,7 @@ export default {
           ctx,
           requestCountryCode: context.requestCountryCode,
           timestamp: context.requestTimestamp,
-          botName,
+          botName: context.botName,
         },
       )
       if (failureResponse) return failureResponse

--- a/piece-retriever/lib/request.js
+++ b/piece-retriever/lib/request.js
@@ -1,8 +1,4 @@
-import {
-  httpAssert,
-  checkBotAuthorization,
-  isValidEthereumAddress,
-} from '@filbeam/retrieval'
+import { httpAssert, isValidEthereumAddress } from '@filbeam/retrieval'
 
 /**
  * Parse params found in path of the request URL
@@ -10,15 +6,13 @@ import {
  * @param {Request} request
  * @param {object} options
  * @param {string} options.DNS_ROOT
- * @param {string} options.BOT_TOKENS
  * @returns {{
  *   payerWalletAddress: string
  *   pieceCid: string
- *   botName?: string
  *   validateCacheMissResponse: boolean
  * }}
  */
-export function parseRequest(request, { DNS_ROOT, BOT_TOKENS }) {
+export function parseRequest(request, { DNS_ROOT }) {
   const url = new URL(request.url)
   console.log('retrieval request', { DNS_ROOT, url })
 
@@ -45,8 +39,7 @@ export function parseRequest(request, { DNS_ROOT, BOT_TOKENS }) {
     `Invalid address: ${payerWalletAddress}. Address must be a valid ethereum address.`,
   )
 
-  const botName = checkBotAuthorization(request, { BOT_TOKENS })
   const validateCacheMissResponse = url.searchParams.has('validate')
 
-  return { payerWalletAddress, pieceCid, botName, validateCacheMissResponse }
+  return { payerWalletAddress, pieceCid, validateCacheMissResponse }
 }

--- a/retrieval/lib/fetch-handler.js
+++ b/retrieval/lib/fetch-handler.js
@@ -3,7 +3,11 @@ import { httpAssert } from './http-assert.js'
 import { redirectLegacyDomain } from './redirect.js'
 import { handleEmptyBodyResponse } from './empty-body-response.js'
 import { setRetrievalResponseHeaders } from './response-headers.js'
-import { recordRetrieval, logRetrievalResult } from './stats.js'
+import {
+  recordRetrieval,
+  logRetrievalResult,
+  logRetrievalError,
+} from './stats.js'
 
 /**
  * The successful retrieval outcome a worker hands back to
@@ -16,7 +20,6 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  *   and returned unchanged.
  * @property {boolean} cacheMiss
  * @property {string} dataSetId
- * @property {string | undefined} botName
  * @property {number} fetchStartedAt
  * @property {(egressBytes: number) => Promise<{
  *   cacheMissEgressBytes?: number
@@ -28,6 +31,15 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  */
 
 /**
+ * A worker's retrieval step: looks up and retrieves the content. Returns the
+ * {@link RetrievalOutcome} to serve, or a {@link Response} when no service
+ * provider could serve the content. An error thrown here is logged as a
+ * retrieval error.
+ *
+ * @typedef {() => Promise<Response | RetrievalOutcome>} Retrieve
+ */
+
+/**
  * Per-request telemetry shared by the success and error logging paths.
  *
  * @typedef {object} RequestContext
@@ -35,6 +47,8 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  * @property {string | null} requestCountryCode - The request's `CF-IPCountry`.
  * @property {number} workerStartedAt - `performance.now()` when the worker
  *   started handling the request.
+ * @property {string} [botName] - The bot name, set by the worker once the
+ *   request has been parsed.
  */
 
 /**
@@ -43,10 +57,12 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  * legacy `*.filcdn.io` requests to `*.filbeam.io`, and turn thrown errors into
  * HTTP responses via {@link handleError}.
  *
- * The handler returns either a plain {@link Response} (redirects, the
- * no-service-provider response, ...), which is served as-is, or a
- * {@link RetrievalOutcome}, whose body is streamed to the client while its
- * egress is measured and the retrieval is logged.
+ * The handler returns either a plain {@link Response} (redirects), served as-is,
+ * or a {@link Retrieve} function. The retrieval is run inside a try/catch that
+ * logs a retrieval error on failure; its result is then served: a
+ * {@link Response} (the no-service-provider response) as-is, or a
+ * {@link RetrievalOutcome} whose body is streamed while egress is measured and
+ * the retrieval is logged.
  *
  * @param {Request} request
  * @param {{
@@ -55,8 +71,10 @@ import { recordRetrieval, logRetrievalResult } from './stats.js'
  *   ENFORCE_EGRESS_QUOTA: boolean
  * }} env
  * @param {ExecutionContext} ctx
- * @param {(context: RequestContext) => Promise<Response | RetrievalOutcome>} run
- *   - Invokes the worker handler with the per-request telemetry context.
+ * @param {(context: RequestContext) => Promise<Response | Retrieve>} run
+ *
+ *   - Invokes the worker handler with the per-request telemetry context. The worker
+ *       sets `context.botName` before returning its retrieval function.
  *
  * @returns {Promise<Response>}
  */
@@ -81,10 +99,23 @@ export async function handleFetchRequest(request, env, ctx, run) {
     const legacyRedirect = redirectLegacyDomain(request)
     if (legacyRedirect) return legacyRedirect
 
-    const result = await run(context)
-    if (result instanceof Response) return result
+    const retrieve = await run(context)
+    if (retrieve instanceof Response) return retrieve
 
-    return serveRetrievalOutcome(env, ctx, result, context)
+    let outcome
+    try {
+      outcome = await retrieve()
+    } catch (error) {
+      logRetrievalError(env, ctx, error, {
+        requestCountryCode: context.requestCountryCode,
+        timestamp: context.requestTimestamp,
+        botName: context.botName,
+      })
+      throw error
+    }
+
+    if (outcome instanceof Response) return outcome
+    return serveRetrievalOutcome(env, ctx, outcome, context)
   } catch (error) {
     return handleError(error)
   }
@@ -108,16 +139,10 @@ function serveRetrievalOutcome(
   env,
   ctx,
   result,
-  { requestCountryCode, requestTimestamp: timestamp, workerStartedAt },
+  { requestCountryCode, requestTimestamp: timestamp, workerStartedAt, botName },
 ) {
-  const {
-    response,
-    cacheMiss,
-    dataSetId,
-    botName,
-    fetchStartedAt,
-    finalizeCacheMiss,
-  } = result
+  const { response, cacheMiss, dataSetId, fetchStartedAt, finalizeCacheMiss } =
+    result
 
   // No readable body (e.g. a HEAD request or an error status): nothing to
   // stream or measure.

--- a/retrieval/lib/fetch-handler.js
+++ b/retrieval/lib/fetch-handler.js
@@ -1,6 +1,7 @@
 import { handleError } from './http-error.js'
 import { httpAssert } from './http-assert.js'
 import { redirectLegacyDomain } from './redirect.js'
+import { checkBotAuthorization } from './bot-auth.js'
 import { handleEmptyBodyResponse } from './empty-body-response.js'
 import { setRetrievalResponseHeaders } from './response-headers.js'
 import {
@@ -47,8 +48,8 @@ import {
  * @property {string | null} requestCountryCode - The request's `CF-IPCountry`.
  * @property {number} workerStartedAt - `performance.now()` when the worker
  *   started handling the request.
- * @property {string} [botName] - The bot name, set by the worker once the
- *   request has been parsed.
+ * @property {string} [botName] - The bot name resolved from the request's
+ *   Authorization header, or `undefined` for anonymous requests.
  */
 
 /**
@@ -69,12 +70,12 @@ import {
  *   DB: D1Database
  *   CLIENT_CACHE_TTL: number
  *   ENFORCE_EGRESS_QUOTA: boolean
+ *   BOT_TOKENS: string
  * }} env
  * @param {ExecutionContext} ctx
  * @param {(context: RequestContext) => Promise<Response | Retrieve>} run
  *
- *   - Invokes the worker handler with the per-request telemetry context. The worker
- *       sets `context.botName` before returning its retrieval function.
+ *   - Invokes the worker handler with the per-request telemetry context.
  *
  * @returns {Promise<Response>}
  */
@@ -98,6 +99,10 @@ export async function handleFetchRequest(request, env, ctx, run) {
     )
     const legacyRedirect = redirectLegacyDomain(request)
     if (legacyRedirect) return legacyRedirect
+
+    context.botName = checkBotAuthorization(request, {
+      BOT_TOKENS: env.BOT_TOKENS,
+    })
 
     const retrieve = await run(context)
     if (retrieve instanceof Response) return retrieve

--- a/retrieval/test/fetch-handler.test.js
+++ b/retrieval/test/fetch-handler.test.js
@@ -10,6 +10,7 @@ const testEnv = {
   ...env,
   CLIENT_CACHE_TTL: 31536000,
   ENFORCE_EGRESS_QUOTA: false,
+  BOT_TOKENS: '{}',
 }
 
 function retrievalResult(overrides = {}) {
@@ -212,5 +213,47 @@ describe('handleFetchRequest', () => {
       .bind(dataSetId)
       .first()
     expect(log).toEqual({ response_status: 900 })
+  })
+
+  it('resolves the bot name from the Authorization header and logs it', async () => {
+    const ctx = createExecutionContext()
+    const dataSetId = 'fh-bot'
+    const res = await handleFetchRequest(
+      new Request('https://example.com/', {
+        headers: { authorization: 'Bearer tok' },
+      }),
+      { ...testEnv, BOT_TOKENS: JSON.stringify({ tok: 'bot-1' }) },
+      ctx,
+      runYielding({ dataSetId }),
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello world')
+    await waitOnExecutionContext(ctx)
+
+    const log = await env.DB.prepare(
+      'SELECT bot_name FROM retrieval_logs WHERE data_set_id = ?',
+    )
+      .bind(dataSetId)
+      .first()
+    expect(log).toEqual({ bot_name: 'bot-1' })
+  })
+
+  it('rejects an unknown bot token with 401 without running the retrieval', async () => {
+    const ctx = createExecutionContext()
+    let ran = false
+    const res = await handleFetchRequest(
+      new Request('https://example.com/', {
+        headers: { authorization: 'Bearer wrong' },
+      }),
+      { ...testEnv, BOT_TOKENS: JSON.stringify({ tok: 'bot-1' }) },
+      ctx,
+      () => {
+        ran = true
+        return Promise.resolve(async () => retrievalResult())
+      },
+    )
+
+    expect(res.status).toBe(401)
+    expect(ran).toBe(false)
   })
 })

--- a/retrieval/test/fetch-handler.test.js
+++ b/retrieval/test/fetch-handler.test.js
@@ -17,11 +17,15 @@ function retrievalResult(overrides = {}) {
     response: new Response('hello world', { status: 200 }),
     cacheMiss: true,
     dataSetId: 'fh-test',
-    botName: undefined,
     fetchStartedAt: performance.now(),
     finalizeCacheMiss: async () => ({ cacheMissResponseValid: true }),
     ...overrides,
   }
+}
+
+/** A `run` that resolves to a retrieve function yielding the given outcome. */
+function runYielding(overrides = {}) {
+  return async () => async () => retrievalResult(overrides)
 }
 
 describe('handleFetchRequest', () => {
@@ -126,14 +130,13 @@ describe('handleFetchRequest', () => {
       }),
       testEnv,
       ctx,
-      async () =>
-        retrievalResult({
-          dataSetId,
-          finalizeCacheMiss: async (egressBytes) => {
-            finalizedEgress = egressBytes
-            return { cacheMissResponseValid: true }
-          },
-        }),
+      runYielding({
+        dataSetId,
+        finalizeCacheMiss: async (egressBytes) => {
+          finalizedEgress = egressBytes
+          return { cacheMissResponseValid: true }
+        },
+      }),
     )
 
     expect(res.status).toBe(200)
@@ -164,11 +167,10 @@ describe('handleFetchRequest', () => {
       new Request('https://example.com/'),
       testEnv,
       ctx,
-      async () =>
-        retrievalResult({
-          dataSetId,
-          response: new Response(null, { status: 404 }),
-        }),
+      runYielding({
+        dataSetId,
+        response: new Response(null, { status: 404 }),
+      }),
     )
     await waitOnExecutionContext(ctx)
 
@@ -196,11 +198,10 @@ describe('handleFetchRequest', () => {
       new Request('https://example.com/'),
       testEnv,
       ctx,
-      async () =>
-        retrievalResult({
-          dataSetId,
-          response: new Response(erroringBody, { status: 200 }),
-        }),
+      runYielding({
+        dataSetId,
+        response: new Response(erroringBody, { status: 200 }),
+      }),
     )
     expect(res.status).toBe(200)
     await waitOnExecutionContext(ctx)


### PR DESCRIPTION
The `try/catch` that logs a retrieval error lived in each worker's `_fetch`. This moves it into `handleFetchRequest` by having `_fetch` return a retrieval function instead of running the retrieval inline.

## _fetch shape

`_fetch` now:
1. handles redirects (returns a `Response`),
2. parses the request,
3. returns an anonymous retrieval function - the work that used to be inside the `try` block.

`handleFetchRequest` runs that function inside a `try/catch`, logging a retrieval error (and rethrowing to `handleError`) on failure. Request-parsing errors still throw out of `run` and are not retrieval-logged, as before.

## Bot authorization moves to the wrapper

To log the bot name from the outer layer without `_fetch` forwarding it, bot authorization moves out of each worker's `parseRequest` and into `handleFetchRequest`, which resolves the bot name into the `RequestContext`. Both the success and error logging paths read it from the context, and `_fetch` keeps returning a plain retrieval function (no context mutation).

A consequence: the bot token is now validated for every request before the worker's own redirects (the `/` and bare-DNS-root redirects), where previously those redirects returned before `parseRequest` ran. An unknown token on a redirect path now yields `401` instead of the redirect.

## Changes

- `retrieval/lib/fetch-handler.js`: `run` returns `Response | Retrieve` (a new `Retrieve` typedef, `() => Promise<Response | RetrievalOutcome>`). `handleFetchRequest` owns the retrieval `try/catch` + `logRetrievalError`, and resolves `context.botName` via `checkBotAuthorization`.
- `parseRequest` (both workers) no longer takes `BOT_TOKENS` or returns `botName`.
- `piece-retriever` and `ipfs-retriever` return a retrieval function and read `context.botName`; neither imports `logRetrievalError` or `checkBotAuthorization`.