### PR TITLE
Deduplicate ipfs-retriever candidates by service provider

### DIFF
--- a/ipfs-retriever/lib/store.js
+++ b/ipfs-retriever/lib/store.js
@@ -74,11 +74,24 @@ function validateQueryResultsAndGetCandidates(params) {
     ipfsRootCid: row.ipfs_root_cid,
   }))
 
+  // Under sharding, one IPFS root CID maps to many pieces on the same service
+  // provider, producing candidates that differ only by piece. Retrieval is by
+  // root CID and never uses the piece, so those are identical requests. Keep
+  // one candidate per service provider, so a failing provider is attempted once
+  // rather than once per shard, while still retrying across distinct providers.
+  const candidatesByServiceProvider = new Map()
+  for (const candidate of candidates) {
+    if (!candidatesByServiceProvider.has(candidate.serviceProviderId)) {
+      candidatesByServiceProvider.set(candidate.serviceProviderId, candidate)
+    }
+  }
+  const dedupedCandidates = [...candidatesByServiceProvider.values()]
+
   console.log(
-    `Validated ${candidates.length} retrieval candidate(s) for ${lookupKey} and payer '${payerAddress}'`,
+    `Validated ${dedupedCandidates.length} retrieval candidate(s) for ${lookupKey} and payer '${payerAddress}'`,
   )
 
-  return candidates
+  return dedupedCandidates
 }
 
 /**

--- a/ipfs-retriever/test/store.test.js
+++ b/ipfs-retriever/test/store.test.js
@@ -275,6 +275,87 @@ describe('getRetrievalCandidatesByWalletAndCid', () => {
       ipfsRootCid,
     })
   })
+
+  it('returns one candidate per service provider when an ipfsRootCid is sharded across many pieces', async () => {
+    const dataSetId = 'sharded-data-set'
+    const ipfsRootCid = 'sharded-ipfs-cid'
+    const payerAddress = '0x1234567890abcdef1234567890abcdef12345678'
+    const serviceProviderId = 'sharded-provider'
+
+    await withApprovedProvider(env, {
+      id: serviceProviderId,
+      serviceUrl: 'https://sharded-provider.xyz',
+    })
+
+    await env.DB.prepare(
+      'INSERT INTO data_sets (id, service_provider_id, payer_address, with_cdn, with_ipfs_indexing) VALUES (?, ?, ?, ?, ?)',
+    )
+      .bind(dataSetId, serviceProviderId, payerAddress, true, true)
+      .run()
+
+    // The same root CID is stored as three pieces (shards) on one provider.
+    for (const pieceId of ['shard-0', 'shard-1', 'shard-2']) {
+      await env.DB.prepare(
+        'INSERT INTO pieces (id, data_set_id, cid, ipfs_root_cid) VALUES (?, ?, ?, ?)',
+      )
+        .bind(pieceId, dataSetId, `baga-${pieceId}`, ipfsRootCid)
+        .run()
+    }
+
+    const result = await getRetrievalCandidatesByWalletAndCid(
+      env,
+      payerAddress,
+      ipfsRootCid,
+    )
+
+    assert.strictEqual(result.length, 1)
+    assert.strictEqual(result[0].serviceProviderId, serviceProviderId)
+    assert.strictEqual(result[0].serviceUrl, 'https://sharded-provider.xyz')
+  })
+
+  it('returns one candidate per distinct service provider when shards span multiple providers', async () => {
+    const ipfsRootCid = 'multi-provider-sharded-cid'
+    const payerAddress = '0x1234567890abcdef1234567890abcdef12345678'
+    const providers = [
+      { id: 'multi-provider-a', serviceUrl: 'https://multi-provider-a.xyz' },
+      { id: 'multi-provider-b', serviceUrl: 'https://multi-provider-b.xyz' },
+    ]
+
+    for (const [i, provider] of providers.entries()) {
+      await withApprovedProvider(env, provider)
+      const dataSetId = `multi-provider-set-${i}`
+      await env.DB.prepare(
+        'INSERT INTO data_sets (id, service_provider_id, payer_address, with_cdn, with_ipfs_indexing) VALUES (?, ?, ?, ?, ?)',
+      )
+        .bind(dataSetId, provider.id, payerAddress, true, true)
+        .run()
+      // Two shards per provider.
+      for (const shard of ['0', '1']) {
+        await env.DB.prepare(
+          'INSERT INTO pieces (id, data_set_id, cid, ipfs_root_cid) VALUES (?, ?, ?, ?)',
+        )
+          .bind(
+            `${provider.id}-shard-${shard}`,
+            dataSetId,
+            `baga-${provider.id}-${shard}`,
+            ipfsRootCid,
+          )
+          .run()
+      }
+    }
+
+    const result = await getRetrievalCandidatesByWalletAndCid(
+      env,
+      payerAddress,
+      ipfsRootCid,
+    )
+
+    assert.strictEqual(result.length, 2)
+    assert.deepStrictEqual(result.map((c) => c.serviceUrl).sort(), [
+      'https://multi-provider-a.xyz',
+      'https://multi-provider-b.xyz',
+    ])
+  })
 })
 
 describe('getRetrievalCandidatesByDataSetAndPiece', () => {


### PR DESCRIPTION
Stacked on #312.
Closes #691

Addresses https://github.com/filbeam/worker/pull/312#discussion_r3469444977.

## Problem

`ipfs-retriever` looks up candidates with `WHERE pieces.ipfs_root_cid = ?`, returning one row per piece. Under Storacha's sharding model one IPFS root CID maps to N pieces (shards) on the same service provider, so the lookup yields N candidates that differ only by piece, all with the same `serviceUrl`.

Retrieval is by IPFS root CID through the trustless gateway. `retrieveIpfsContent` uses only `serviceUrl` and `ipfsRootCid`, never the piece, so every one of those candidates is the exact same HTTP request. `selectRetrievalCandidate` then retries across all N on failure, hitting a genuinely failing provider N times before returning the 502.

## Fix

Deduplicate candidates by service provider in `validateQueryResultsAndGetCandidates`, after the authorization and quota cascade. A failing provider is now attempted once rather than once per shard, while retries across distinct providers (content replicated across providers) are preserved. This also makes the code match the existing JSDoc, which already documents "one per service provider".

The dedup lives in the `ipfs-retriever` lookup rather than the shared `selectRetrievalCandidate`, because `piece-retriever` retrieves by piece CID, where candidates sharing a `serviceUrl` are distinct requests and must not be collapsed.
