### PR TITLE
Add IPFS retrieval schema migrations

### DIFF
--- a/db/migrations/0028_retrieval_logs_cache_miss_egress_bytes.sql
+++ b/db/migrations/0028_retrieval_logs_cache_miss_egress_bytes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE retrieval_logs ADD COLUMN cache_miss_egress_bytes INTEGER;

--- a/db/migrations/0029_add_ipfs_root_cid_index.sql
+++ b/db/migrations/0029_add_ipfs_root_cid_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX pieces_ipfs_root_cid ON pieces(ipfs_root_cid);


### PR DESCRIPTION
Extracts the schema changes from #312 into their own PR, targeting `main`.

## Motivation

We want to merge and deploy these migrations before #312. With the columns and index already present on the production database, we can stand up a manual test/preview deployment of the `ipfs-retriever` worker on top of the production database, ahead of landing the full worker.

## Changes

- `0028_retrieval_logs_cache_miss_egress_bytes.sql` - adds a nullable `cache_miss_egress_bytes` column to `retrieval_logs`, used to record CAR bytes fetched from the SP on a cache miss separately from client egress.
- `0029_add_ipfs_root_cid_index.sql` - adds an index on `pieces.ipfs_root_cid`, which the `ipfs-retriever` candidate lookup filters on.

Both are additive and backward-compatible. No currently-deployed worker reads or writes the new column, and the index is purely additive, so deploying these ahead of #312 does not affect the running workers.
