### PR TITLE
fix: migrate Goldsky webhook sinks to filbeam.io

### DIFF
--- a/indexer/wrangler.toml
+++ b/indexer/wrangler.toml
@@ -74,6 +74,10 @@ binding = "RETRY_QUEUE"
 binding = "PROCESSED_EVENTS"
 id = "b18c3c10-fake-dev-id"
 
+[env.calibration.route]
+pattern = "index.calibration.filbeam.io/*"
+zone_name = "filbeam.io"
+
 [env.calibration.vars]
 ENVIRONMENT = "calibration"
 WALLET_SCREENING_BATCH_SIZE = 1
@@ -113,6 +117,10 @@ max_batch_timeout = 30
 [[env.calibration.kv_namespaces]]
 binding = "PROCESSED_EVENTS"
 id = "86018fc9b60a462bbfd3a08c66680ffc"
+
+[env.mainnet.route]
+pattern = "index.filbeam.io/*"
+zone_name = "filbeam.io"
 
 [env.mainnet.vars]
 ENVIRONMENT = "mainnet"

--- a/subgraph/pipelines/calibnet.yaml
+++ b/subgraph/pipelines/calibnet.yaml
@@ -71,67 +71,67 @@ sources:
 transforms: {}
 sinks:
   sink__fwss__data_set_created:
-    url: https://index.calibration.filcdn.io/fwss/data-set-created
+    url: https://index.calibration.filbeam.io/fwss/data-set-created
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__data_set_created
   sink__service_provider_registry__product_added:
-    url: https://index.calibration.filcdn.io/service-provider-registry/product-added
+    url: https://index.calibration.filbeam.io/service-provider-registry/product-added
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: source__service_provider_registry__product_added
   sink__fwss__piece_added:
-    url: https://index.calibration.filcdn.io/fwss/piece-added
+    url: https://index.calibration.filbeam.io/fwss/piece-added
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__piece_added
   sink__fwss__service_terminated:
-    url: https://index.calibration.filcdn.io/fwss/service-terminated
+    url: https://index.calibration.filbeam.io/fwss/service-terminated
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__service_terminated
   sink__service_provider_registry__product_updated:
-    url: https://index.calibration.filcdn.io/service-provider-registry/product-updated
+    url: https://index.calibration.filbeam.io/service-provider-registry/product-updated
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: source__service_provider_registry__product_updated
   sink__pdp__pieces_removed:
-    url: https://index.calibration.filcdn.io/pdp-verifier/pieces-removed
+    url: https://index.calibration.filbeam.io/pdp-verifier/pieces-removed
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__pieces_removed
   sink_fwss_cdn_service_terminated:
-    url: https://index.calibration.filcdn.io/fwss/cdn-service-terminated
+    url: https://index.calibration.filbeam.io/fwss/cdn-service-terminated
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__cdn_service_terminated
   sink__fwss__cdn_payment_rails_topped_up:
-    url: https://index.calibration.filcdn.io/fwss/cdn-payment-rails-topped-up
+    url: https://index.calibration.filbeam.io/fwss/cdn-payment-rails-topped-up
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__cdn_payment_rails_topped_up
   sink__filbeam_operator__cdn_payment_settled:
-    url: https://index.calibration.filcdn.io/filbeam-operator/cdn-payment-settled
+    url: https://index.calibration.filbeam.io/filbeam-operator/cdn-payment-settled
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__cdn_payment_settled
   sink__service_provider_registry__product_removed:
-    url: https://index.calibration.filcdn.io/service-provider-registry/product-removed
+    url: https://index.calibration.filbeam.io/service-provider-registry/product-removed
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: source__service_provider_registry__product_removed
   sink_service_provider_registry__provider_removed:
-    url: https://index.calibration.filcdn.io/service-provider-registry/provider-removed
+    url: https://index.calibration.filbeam.io/service-provider-registry/provider-removed
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true

--- a/subgraph/pipelines/mainnet.yaml
+++ b/subgraph/pipelines/mainnet.yaml
@@ -71,67 +71,67 @@ sources:
 transforms: {}
 sinks:
   sink__fwss__data_set_created:
-    url: https://index.filcdn.io/fwss/data-set-created
+    url: https://index.filbeam.io/fwss/data-set-created
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__data_set_created
   sink__service_provider_registry__product_added:
-    url: https://index.filcdn.io/service-provider-registry/product-added
+    url: https://index.filbeam.io/service-provider-registry/product-added
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: source__service_provider_registry__product_added
   sink__fwss__piece_added:
-    url: https://index.filcdn.io/fwss/piece-added
+    url: https://index.filbeam.io/fwss/piece-added
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__piece_added
   sink__fwss__service_terminated:
-    url: https://index.filcdn.io/fwss/service-terminated
+    url: https://index.filbeam.io/fwss/service-terminated
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__service_terminated
   sink__service_provider_registry__product_updated:
-    url: https://index.filcdn.io/service-provider-registry/product-updated
+    url: https://index.filbeam.io/service-provider-registry/product-updated
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: source__service_provider_registry__product_updated
   sink__pdp__pieces_removed:
-    url: https://index.filcdn.io/pdp-verifier/pieces-removed
+    url: https://index.filbeam.io/pdp-verifier/pieces-removed
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__pieces_removed
   sink_fwss_cdn_service_terminated:
-    url: https://index.filcdn.io/fwss/cdn-service-terminated
+    url: https://index.filbeam.io/fwss/cdn-service-terminated
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__cdn_service_terminated
   sink__fwss__cdn_payment_rails_topped_up:
-    url: https://index.filcdn.io/fwss/cdn-payment-rails-topped-up
+    url: https://index.filbeam.io/fwss/cdn-payment-rails-topped-up
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__cdn_payment_rails_topped_up
   sink__filbeam_operator__cdn_payment_settled:
-    url: https://index.filcdn.io/filbeam-operator/cdn-payment-settled
+    url: https://index.filbeam.io/filbeam-operator/cdn-payment-settled
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: filbeam__cdn_payment_settled
   sink__service_provider_registry__product_removed:
-    url: https://index.filcdn.io/service-provider-registry/product-removed
+    url: https://index.filbeam.io/service-provider-registry/product-removed
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true
     from: source__service_provider_registry__product_removed
   sink_service_provider_registry__provider_removed:
-    url: https://index.filcdn.io/service-provider-registry/provider-removed
+    url: https://index.filbeam.io/service-provider-registry/provider-removed
     type: webhook
     secret_name: WEBHOOK_SECRET_CMBHIZHPO0
     one_row_per_request: true


### PR DESCRIPTION
## Summary

- add exact `filbeam.io` Worker routes for the calibration and mainnet indexers
- migrate all 11 Goldsky webhook sinks per environment from the retired `filcdn.io` hosts to `filbeam.io`
- preserve the existing pipeline sources, sink keys, authentication secret, and delivery settings

## Root cause

The legacy `filcdn.io` domain was intentionally retired and removed from Cloudflare, but the Goldsky pipeline definitions still used `index.calibration.filcdn.io` and `index.filcdn.io`. When DNS delegation disappeared, both pipelines continued reading source records but could no longer connect to their webhook sinks, causing the delivery outage described in #698.

## Rollout

1. Deploy the calibration indexer route and verify an unauthenticated POST to `index.calibration.filbeam.io` returns `401` from the indexer rather than `405` from the piece-retriever wildcard.
2. Apply the updated Calibnet pipeline from its last snapshot and verify backlog recovery, including data set `18197`, piece `3`.
3. Only after Calibnet is healthy, repeat the route deployment and pipeline update for mainnet.

Refs #698 and #694.

## Validation

- `npm run lint:fix`
- `npm test` — 34 test files, 381 tests passed
- `npx wrangler deploy --dry-run --env calibration --config indexer/wrangler.toml`
- `npx wrangler deploy --dry-run --env mainnet --config indexer/wrangler.toml`
